### PR TITLE
ci: add jobs to publish to PyPi

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,13 +8,6 @@ on:
       - "*"
   pull_request:
   workflow_call:
-    inputs:
-      config-path:
-        required: true
-        type: string
-    secrets:
-      token:
-        required: true
 
 env:
   HATCH_VERSION: "v1.7.0" # keep in sync with deploy.yml

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,7 @@ on:
         required: true
 
 env:
-  HATCH_VERSION: "v1.7.0"
+  HATCH_VERSION: "v1.7.0" # keep in sync with deploy.yml
 
 jobs:
   format-black:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,6 +7,14 @@ on:
     tags:
       - "*"
   pull_request:
+  workflow_call:
+    inputs:
+      config-path:
+        required: true
+        type: string
+    secrets:
+      token:
+        required: true
 
 env:
   HATCH_VERSION: "v1.7.0"
@@ -80,7 +88,7 @@ jobs:
 
   scan-for-secrets:
     name: Scan for secrets
-    runs-on: self-hosted-dc
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -123,21 +131,3 @@ jobs:
         run: pip install hatch==${{ env.HATCH_VERSION }}
       - name: Build
         run: hatch build
-
-  # to deploy to test, name your branch matching the pattern testdeploy/*
-  test-publish:
-    name: Release to Test PyPi
-    environment: test
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: pypa/gh-action-pypi-publish@release/v1
-
-  # deploys on main
-  publish:
-    name: Release to PyPi
-    environment: release
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -131,7 +131,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@release/v1
 
   # deploys on main
   publish:
@@ -140,4 +140,4 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -110,9 +110,8 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ github.token }}
 
-  release:
-    name: Release
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+  build:
+    name: Build package
     needs: [format-black, mypy, lint, tests]
     runs-on: ubuntu-latest
     steps:
@@ -124,7 +123,17 @@ jobs:
         run: pip install hatch==${{ env.HATCH_VERSION }}
       - name: Build
         run: hatch build
-      # - name: Release
-      #   uses: some-release/action
-      #   with:
-      #     files: "dist/*"
+
+  # to deploy to test, name your branch matching the pattern testdeploy/*
+  test-release:
+    name: Release to Test PyPi
+    environment: test
+    needs: [build]
+    uses: pypa/gh-action-pypi-publish@release/v1
+
+  # deploys on main
+  release:
+    name: Release to PyPi
+    environment: release
+    needs: [build]
+    uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -125,15 +125,19 @@ jobs:
         run: hatch build
 
   # to deploy to test, name your branch matching the pattern testdeploy/*
-  test-release:
+  test-publish:
     name: Release to Test PyPi
     environment: test
     needs: [build]
-    uses: pypa/gh-action-pypi-publish@release/v1
+    runs-on: ubuntu-latest
+    steps:
+      uses: pypa/gh-action-pypi-publish@release/v1
 
   # deploys on main
-  release:
+  publish:
     name: Release to PyPi
     environment: release
     needs: [build]
-    uses: pypa/gh-action-pypi-publish@release/v1
+    runs-on: ubuntu-latest
+    steps:
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -7,8 +7,6 @@ on:
 
 jobs:
   deploy-prod:
-    name: Deploy SDK PyPi
-    runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     uses: ./.github/workflows/deploy.yml
     with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,6 +10,7 @@ jobs:
     name: Deploy SDK PyPi
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Deploy To Prod PyPi
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,4 +10,4 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     uses: ./.github/workflows/deploy.yml
     with:
-      deployment-env: release
+      deployment_env: release

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -9,9 +9,7 @@ jobs:
   deploy-prod:
     name: Deploy SDK PyPi
     runs-on: ubuntu-latest
-    steps:
-      - name: Deploy To Prod PyPi
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: ./.github/workflows/deploy.yml
-        with:
-          deployment-env: release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    uses: ./.github/workflows/deploy.yml
+    with:
+      deployment-env: release

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,9 +1,9 @@
 name: Deploy to Prod PyPi
 
 on:
-  pull_request:
-    types:
-      - labeled
+  push:
+    branches:
+      - main
 
 jobs:
   deploy-prod:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,7 +10,6 @@ jobs:
     name: Deploy SDK PyPi
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - name: Deploy To Prod PyPi
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,14 @@
+name: Deploy to Prod PyPi
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+
+steps:
+  - name: Deploy To Prod PyPi
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    uses: ./.github/workflows/deploy.yml
+    with:
+      deployment-env: release

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   deploy-prod:
+    name: Deploy SDK PyPi
+    runs-on: ubuntu-latest
     steps:
       - name: Deploy To Prod PyPi
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   deploy-prod:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     uses: ./.github/workflows/deploy.yml
     with:
       deployment_env: release

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -5,10 +5,11 @@ on:
     types:
       - labeled
 
-
-steps:
-  - name: Deploy To Prod PyPi
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    uses: ./.github/workflows/deploy.yml
-    with:
-      deployment-env: release
+jobs:
+  deploy-prod:
+    steps:
+      - name: Deploy To Prod PyPi
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: ./.github/workflows/deploy.yml
+        with:
+          deployment-env: release

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -5,10 +5,11 @@ on:
     types:
       - labeled
 
-
-steps:
-  - name: Deploy To Test PyPi
-    if: ${{ github.event.label.name == 'test-deploy' }}
-    uses: ./.github/workflows/deploy.yml
-    with:
-      deployment-env: test
+jobs:
+  deploy-test:
+    steps:
+      - name: Deploy To Test PyPi
+        if: ${{ github.event.label.name == 'test-deploy' }}
+        uses: ./.github/workflows/deploy.yml
+        with:
+          deployment-env: test

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -5,9 +5,6 @@ on:
     types:
       - labeled
   workflow_dispatch:
-  push:
-    branches:
-      - ci/release-job
 
 jobs:
   deploy-test:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -5,6 +5,9 @@ on:
     types:
       - labeled
   workflow_dispatch:
+  push:
+    branches:
+      - ci/release-job
 
 jobs:
   deploy-test:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -11,4 +11,4 @@ jobs:
     if: ${{ github.event.label.name == 'test-deploy' }}`
     uses: ./.github/workflows/deploy.yml
     with:
-      deployment-env: test
+      deployment_env: test

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -14,7 +14,6 @@ jobs:
     name: Deploy SDK Test PyPi
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - name: Deploy To Test PyPi
         if: ${{ github.event.label.name == 'test-deploy' }}
         uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   deploy-test:
+    name: Deploy SDK Test PyPi
+    runs-on: ubuntu-latest
     steps:
       - name: Deploy To Test PyPi
         if: ${{ github.event.label.name == 'test-deploy' }}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -8,9 +8,7 @@ on:
 
 jobs:
   deploy-test:
-    name: Deploy SDK Test PyPi
-    runs-on: ubuntu-latest
-    if: ${{ github.event.label.name == 'test-deploy' }}
+    if: ${{ github.event.label.name == 'test-deploy' }}`
     uses: ./.github/workflows/deploy.yml
     with:
       deployment-env: test

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,0 +1,14 @@
+name: Deploy to Test PyPi
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+
+steps:
+  - name: Deploy To Test PyPi
+    if: ${{ github.event.label.name == 'test-deploy' }}
+    uses: ./.github/workflows/deploy.yml
+    with:
+      deployment-env: test

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -13,9 +13,7 @@ jobs:
   deploy-test:
     name: Deploy SDK Test PyPi
     runs-on: ubuntu-latest
-    steps:
-      - name: Deploy To Test PyPi
-        if: ${{ github.event.label.name == 'test-deploy' }}
-        uses: ./.github/workflows/deploy.yml
-        with:
-          deployment-env: test
+    if: ${{ github.event.label.name == 'test-deploy' }}
+    uses: ./.github/workflows/deploy.yml
+    with:
+      deployment-env: test

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
       - labeled
+  workflow_dispatch:
 
 jobs:
   deploy-test:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -14,6 +14,7 @@ jobs:
     name: Deploy SDK Test PyPi
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Deploy To Test PyPi
         if: ${{ github.event.label.name == 'test-deploy' }}
         uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy
+
+on:
+  workflow_call:
+    inputs:
+      config-path:
+        required: true
+        type: string
+    env:
+      deployment-env:
+        required: true
+
+
+steps:
+  - name: ci
+    uses: ./.github/workflows/continuous-integration.yml
+
+  # to deploy to test, name your branch matching the pattern testdeploy/*
+  - name: publish
+    needs: [ci]
+    runs-on: ubuntu-latest
+    environment: ${{env.deployment-env}}
+    env:
+      pypi: ${{ env.PYPI_URL }}
+    uses: pypa/gh-action-pypi-publish@release/v1
+    with:
+      repository-url: ${{env.pypi}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  id-token: write
+
 env:
   HATCH_VERSION: "v1.7.0" # keep in sync with continuous-integration.yml
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       deployment_env:
         required: true
+        type: string
 
 env:
   HATCH_VERSION: "v1.7.0" # keep in sync with continuous-integration.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,6 @@ name: Deploy
 on:
   workflow_call:
     inputs:
-      config-path:
-        required: true
-        type: string
-    env:
       deployment-env:
         required: true
 
@@ -22,7 +18,7 @@ jobs:
 
       - name: publish
         runs-on: ubuntu-latest
-        environment: ${{env.deployment-env}}
+        environment: ${{inputs.deployment-env}}
         env:
           pypi: ${{ env.PYPI_URL }}
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   deploy:
     steps:
+      - uses: actions/checkout@v3
+
       - name: ci
         uses: ./.github/workflows/continuous-integration.yml
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,7 @@ on:
         required: true
 
 env:
-  HATCH_VERSION: "v1.7.0"
-
+  HATCH_VERSION: "v1.7.0" # keep in sync with continuous-integration.yml
 
 jobs:
   ci:
@@ -19,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{inputs.deployment_env}}
     env:
-      pypi: ${{ env.PYPI_URL }}
+      pypi: ${{ vars.PYPI_URL }}
 
     steps:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,18 +10,19 @@ on:
       deployment-env:
         required: true
 
+jobs:
+  deploy:
+    steps:
+      - name: ci
+        uses: ./.github/workflows/continuous-integration.yml
 
-steps:
-  - name: ci
-    uses: ./.github/workflows/continuous-integration.yml
-
-  # to deploy to test, name your branch matching the pattern testdeploy/*
-  - name: publish
-    needs: [ci]
-    runs-on: ubuntu-latest
-    environment: ${{env.deployment-env}}
-    env:
-      pypi: ${{ env.PYPI_URL }}
-    uses: pypa/gh-action-pypi-publish@release/v1
-    with:
-      repository-url: ${{env.pypi}}
+      # to deploy to test, name your branch matching the pattern testdeploy/*
+      - name: publish
+        needs: [ci]
+        runs-on: ubuntu-latest
+        environment: ${{env.deployment-env}}
+        env:
+          pypi: ${{ env.PYPI_URL }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{env.pypi}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,17 +10,17 @@ on:
       deployment-env:
         required: true
 
+
 jobs:
+  ci:
+    uses: ./.github/workflows/continuous-integration.yml
+
   deploy:
+    needs: [ci]
     steps:
       - uses: actions/checkout@v3
 
-      - name: ci
-        uses: ./.github/workflows/continuous-integration.yml
-
-      # to deploy to test, name your branch matching the pattern testdeploy/*
       - name: publish
-        needs: [ci]
         runs-on: ubuntu-latest
         environment: ${{env.deployment-env}}
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,24 +3,36 @@ name: Deploy
 on:
   workflow_call:
     inputs:
-      deployment-env:
+      deployment_env:
         required: true
+
+env:
+  HATCH_VERSION: "v1.7.0"
 
 
 jobs:
   ci:
     uses: ./.github/workflows/continuous-integration.yml
 
-  deploy:
+  build-and-deploy:
     needs: [ci]
+    runs-on: ubuntu-latest
+    environment: ${{inputs.deployment_env}}
+    env:
+      pypi: ${{ env.PYPI_URL }}
+
     steps:
+
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+         python-version: "3.10"
+      - name: Install Hatch
+        run: pip install hatch==${{ env.HATCH_VERSION }}
+      - name: Build
+        run: hatch build
 
       - name: publish
-        runs-on: ubuntu-latest
-        environment: ${{inputs.deployment-env}}
-        env:
-          pypi: ${{ env.PYPI_URL }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: ${{env.pypi}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+## Setup
+
+### To build from source
+
+Install hatch
+```
+pip install hatch=="v1.7.0"
+```
+
+### Install pre commit hooks
+```
+hatch run code-quality:hooks
+```
+
+## Deploying to Test PyPi
+
+When you create a PR in the deepset-cloud-sdk repository, adding the 'test-deploy' label will trigger a deployment to the test PyPi repository.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Deepset Cloud SDK
+# deepset Cloud SDK
 
 ## SDK
 

--- a/README.md
+++ b/README.md
@@ -1,50 +1,9 @@
-# platform-python-template
+# Deepset Cloud SDK
 
-This repository can be used as a template for other platform-engineering python based repositories.
+## SDK
 
-It already contains:
+*Add details on how to use the API here*
 
-  - issue templates
-  - PR template
-  - workflows for:
-    - compliance
-    - velocity metrics
-    - dependabot configuration
-    - high-priority bugs
-    - code quality and unit tests
-    - secret scanning
-  - basic code $ test structure
-  - .gitignore
-  - builds using hatch
-  - pre commit config
+## CLI
 
-# Setup
-
-Install hatch
-```
-pip install hatch=="v1.7.0"
-```
-
-To use the precommit hooks please run:
-```
-hatch run code-quality:hooks
-```
-
-## Secrets to add in your new repository
-
-**SLACK**
-
-  - SLACK_WEBHOOK_URL - the webhook for posting a message to slack
-  - SLACK_WEBHOOK_BUG_ALERT_URL - the webhook for posting a high priority bug alert to slack
-
-**FOSSA**
-
-  - FOSSA_LICENSE_SCAN_TOKEN
-
-**GITHUB**
-
-  - VELOCITY_METRICS_ORG_READ_TOKEN - github token with read permissions for the current github repo
-
-**DATADOG**
-
-  - VELOCITY_METRICS_DATADOG_API_KEY
+*Add details on how to use the CLI here*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,3 +122,12 @@ good-names=[
   "_",
   "f1"
   ]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.github",
+  "/tests",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "platform-python-template"
+name = "deepset-cloud-sdk"
 dynamic = ["version"]
-description = 'a python template for deepset projects'
+description = 'deepset cloud SDK'
 readme = "README.md"
 requires-python = ">=3.8"
 license = "MIT"
@@ -30,9 +30,9 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://github.com/unknown/platform-python-template#readme"
-Issues = "https://github.com/unknown/platform-python-template/issues"
-Source = "https://github.com/unknown/platform-python-template"
+Documentation = "https://github.com/deepset-ai/deepset-cloud-sdk#readme"
+Issues = "https://github.com/deepset-ai/deepset-cloud-sdk/issues"
+Source = "https://github.com/deepset-ai/deepset-cloud-sdk"
 
 [tool.hatch.version]
 path = "src/__about__.py"


### PR DESCRIPTION
### Related Issues

- related [#2683](https://github.com/deepset-ai/haystack-hub-api/issues/2863)

### Proposed Changes?

Adds workflow jobs to publish to PyPi and TestPyPi

### How did you test it?
https://github.com/deepset-ai/deepset-cloud-sdk/actions/runs/4928630145

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [x] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
