### PR TITLE
feat: retry read calls for upload sessions

### DIFF
--- a/deepset_cloud_sdk/_service/files_service.py
+++ b/deepset_cloud_sdk/_service/files_service.py
@@ -199,7 +199,7 @@ class FilesService:
         logger.info("Validating file paths and metadata.")
         allowed_suffixes = {".txt", ".json", ".pdf"}
         for file_path in file_paths:
-            if not file_path.suffix.lower() in allowed_suffixes:
+            if file_path.suffix.lower() not in allowed_suffixes:
                 raise ValueError(
                     f"Invalid file extension: {file_path.suffix}. You can upload TXT and PDF files. Metadata files should have the `.meta.json` extension."
                 )
@@ -219,7 +219,7 @@ class FilesService:
         not_mapped_meta_files = [
             meta_file_name
             for meta_file_name in meta_file_names
-            if not (meta_file_name.split(".meta.json")[0]) in file_name_set
+            if meta_file_name.split(".meta.json")[0] not in file_name_set
         ]
 
         if len(not_mapped_meta_files) > 0:

--- a/tests/integration/api/test_integration_files.py
+++ b/tests/integration/api/test_integration_files.py
@@ -1,9 +1,8 @@
-import httpx
 import pytest
 
 from deepset_cloud_sdk._api.config import CommonConfig
 from deepset_cloud_sdk._api.deepset_cloud_api import DeepsetCloudAPI
-from deepset_cloud_sdk._api.files import File, FilesAPI
+from deepset_cloud_sdk._api.files import FilesAPI
 
 
 @pytest.fixture
@@ -24,7 +23,7 @@ class TestListFiles:
             )
 
             assert result.total == 1
-            assert result.has_more == False
+            assert result.has_more is False
             assert len(result.data) == 1
             found_file = result.data[0]
             assert found_file.name == "20_Light_of_the_Seven.txt"

--- a/tests/integration/api/test_integration_upload_sessions.py
+++ b/tests/integration/api/test_integration_upload_sessions.py
@@ -1,4 +1,3 @@
-import httpx
 import pytest
 
 from deepset_cloud_sdk._api.config import CommonConfig
@@ -52,6 +51,6 @@ class TestCreateUploadSessions:
             )
 
             assert result.total > 0
-            assert result.has_more == True
+            assert result.has_more is True
             assert result.data is not None
             assert len(result.data) == 3

--- a/tests/integration/service/test_integration_files_service.py
+++ b/tests/integration/service/test_integration_files_service.py
@@ -6,7 +6,6 @@ import pytest
 from deepset_cloud_sdk._api.config import CommonConfig
 from deepset_cloud_sdk._api.files import File
 from deepset_cloud_sdk._api.upload_sessions import WriteMode
-from deepset_cloud_sdk._s3.upload import S3
 from deepset_cloud_sdk._service.files_service import DeepsetCloudFile, FilesService
 
 

--- a/tests/unit/api/test_files.py
+++ b/tests/unit/api/test_files.py
@@ -5,7 +5,6 @@ from uuid import UUID
 import httpx
 import pytest
 
-from deepset_cloud_sdk._api.deepset_cloud_api import DeepsetCloudAPI
 from deepset_cloud_sdk._api.files import File, FileList, FilesAPI
 
 

--- a/tests/unit/api/test_upload_sessions.py
+++ b/tests/unit/api/test_upload_sessions.py
@@ -113,6 +113,32 @@ class TestStatusUploadSessions:
             workspace_name="sdk_read", endpoint=f"upload_sessions/{session_id}"
         )
 
+    async def test_get_session_status_with_retry(
+        self, upload_session_client: UploadSessionsAPI, mocked_deepset_cloud_api: Mock
+    ) -> None:
+        session_id = uuid4()
+        expires_at = datetime.datetime.now()
+
+        mocked_deepset_cloud_api.get.side_effect = [
+            Response(status_code=codes.BAD_GATEWAY),
+            Response(
+                status_code=codes.OK,
+                json={
+                    "session_id": str(session_id),
+                    "expires_at": expires_at.isoformat(),
+                    "documentation_url": "https://docs.cloud.deepset.ai/docs",
+                    "ingestion_status": {"failed_files": 0, "finished_files": 0},
+                },
+            ),
+        ]
+
+        upload_session_status = await upload_session_client.status(workspace_name="sdk_read", session_id=session_id)
+        assert upload_session_status.session_id == session_id
+        assert upload_session_status.expires_at == expires_at
+        assert upload_session_status.documentation_url == "https://docs.cloud.deepset.ai/docs"
+        assert upload_session_status.ingestion_status.failed_files == 0
+        assert upload_session_status.ingestion_status.finished_files == 0
+
     async def test_get_session_status_failed(
         self, upload_session_client: UploadSessionsAPI, mocked_deepset_cloud_api: Mock
     ) -> None:
@@ -153,6 +179,52 @@ class TestListUploadSessions:
                 "total": 23,
             },
         )
+        result: UploadSessionDetailList = await upload_session_client.list(
+            workspace_name="sdk_read", limit=1, page_number=10
+        )
+        assert result.has_more is True
+        assert result.total == 23
+        assert len(result.data) == 1
+        assert result.data[0].session_id == session_id
+        assert result.data[0].created_by.given_name == "Kristof"
+        assert result.data[0].created_by.family_name == "Test"
+        assert result.data[0].created_by.user_id == user_id
+        assert result.data[0].created_at == timestamp
+        assert result.data[0].expires_at == timestamp
+        assert result.data[0].write_mode == UploadSessionWriteModeEnum.KEEP
+        assert result.data[0].status == UploadSessionStatusEnum.OPEN
+
+    async def test_list_sessions_with_retry(
+        self, upload_session_client: UploadSessionsAPI, mocked_deepset_cloud_api: Mock
+    ) -> None:
+        session_id = uuid4()
+        timestamp = datetime.datetime.now()
+        user_id = uuid4()
+
+        mocked_deepset_cloud_api.get.side_effect = [
+            Response(status_code=codes.BAD_GATEWAY),
+            Response(
+                status_code=codes.OK,
+                json={
+                    "data": [
+                        {
+                            "session_id": str(session_id),
+                            "created_by": {
+                                "given_name": "Kristof",
+                                "family_name": "Test",
+                                "user_id": str(user_id),
+                            },
+                            "created_at": timestamp.isoformat(),
+                            "expires_at": timestamp.isoformat(),
+                            "write_mode": "KEEP",
+                            "status": "OPEN",
+                        },
+                    ],
+                    "has_more": True,
+                    "total": 23,
+                },
+            ),
+        ]
         result: UploadSessionDetailList = await upload_session_client.list(
             workspace_name="sdk_read", limit=1, page_number=10
         )

--- a/tests/unit/api/test_upload_sessions.py
+++ b/tests/unit/api/test_upload_sessions.py
@@ -113,14 +113,15 @@ class TestStatusUploadSessions:
             workspace_name="sdk_read", endpoint=f"upload_sessions/{session_id}"
         )
 
+    @pytest.mark.parametrize("first_status_code", [codes.BAD_GATEWAY, codes.INTERNAL_SERVER_ERROR])
     async def test_get_session_status_with_retry(
-        self, upload_session_client: UploadSessionsAPI, mocked_deepset_cloud_api: Mock
+        self, upload_session_client: UploadSessionsAPI, mocked_deepset_cloud_api: Mock, first_status_code: int
     ) -> None:
         session_id = uuid4()
         expires_at = datetime.datetime.now()
 
         mocked_deepset_cloud_api.get.side_effect = [
-            Response(status_code=codes.BAD_GATEWAY),
+            Response(status_code=first_status_code),
             Response(
                 status_code=codes.OK,
                 json={
@@ -194,15 +195,16 @@ class TestListUploadSessions:
         assert result.data[0].write_mode == UploadSessionWriteModeEnum.KEEP
         assert result.data[0].status == UploadSessionStatusEnum.OPEN
 
+    @pytest.mark.parametrize("first_status_code", [codes.BAD_GATEWAY, codes.INTERNAL_SERVER_ERROR])
     async def test_list_sessions_with_retry(
-        self, upload_session_client: UploadSessionsAPI, mocked_deepset_cloud_api: Mock
+        self, upload_session_client: UploadSessionsAPI, mocked_deepset_cloud_api: Mock, first_status_code: int
     ) -> None:
         session_id = uuid4()
         timestamp = datetime.datetime.now()
         user_id = uuid4()
 
         mocked_deepset_cloud_api.get.side_effect = [
-            Response(status_code=codes.BAD_GATEWAY),
+            Response(status_code=first_status_code),
             Response(
                 status_code=codes.OK,
                 json={

--- a/tests/unit/service/test_files_service.py
+++ b/tests/unit/service/test_files_service.py
@@ -8,7 +8,7 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
 from deepset_cloud_sdk._api.config import CommonConfig
-from deepset_cloud_sdk._api.files import File, FileList, FilesAPI
+from deepset_cloud_sdk._api.files import File, FileList
 from deepset_cloud_sdk._api.upload_sessions import (
     UploadSession,
     UploadSessionIngestionStatus,
@@ -103,7 +103,7 @@ class TestUploadsFileService:
             )
             assert mocked_upload_file_paths.called
             assert "test_workspace" == mocked_upload_file_paths.call_args[1]["workspace_name"]
-            assert mocked_upload_file_paths.call_args[1]["blocking"] == True
+            assert mocked_upload_file_paths.call_args[1]["blocking"] is True
             assert 300 == mocked_upload_file_paths.call_args[1]["timeout_s"]
 
             assert (


### PR DESCRIPTION
### Related Issues

- hotfix

### Proposed Changes?

- we have seen that the api can sporadically return a 502 if its under load during uploading. So we should add a retry to listing the sessions and fetching the status

### How did you test it?
- unit tests 

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
