### PR TITLE
feat: set X-Client-Source for product metrics

### DIFF
--- a/deepset_cloud_sdk/_api/deepset_cloud_api.py
+++ b/deepset_cloud_sdk/_api/deepset_cloud_api.py
@@ -35,6 +35,7 @@ class DeepsetCloudAPI:
         self.headers = {
             "Accept": "application/json",
             "Authorization": f"Bearer {config.api_key}",
+            "X-Client-Source": "deepset-cloud-sdk",
         }
         self.base_url = lambda workspace_name: self._get_base_url(config.api_url)(workspace_name)
         self.client = client

--- a/tests/unit/api/test_deepset_cloud_api.py
+++ b/tests/unit/api/test_deepset_cloud_api.py
@@ -21,6 +21,7 @@ class TestUtilitiesForDeepsetCloudAPI:
             assert deepset_cloud_api.headers == {
                 "Accept": "application/json",
                 "Authorization": f"Bearer {unit_config.api_key}",
+                "X-Client-Source": "deepset-cloud-sdk",
             }
 
     async def test_deepset_cloud_api_raises_exception_if_no_workspace_is_defined(
@@ -60,6 +61,7 @@ class TestCRUDForDeepsetCloudAPI:
             headers={
                 "Accept": "application/json",
                 "Authorization": f"Bearer {unit_config.api_key}",
+                "X-Client-Source": "deepset-cloud-sdk",
             },
             timeout=123,
         )
@@ -87,6 +89,7 @@ class TestCRUDForDeepsetCloudAPI:
             headers={
                 "Accept": "application/json",
                 "Authorization": f"Bearer {unit_config.api_key}",
+                "X-Client-Source": "deepset-cloud-sdk",
             },
             timeout=123,
         )
@@ -107,6 +110,7 @@ class TestCRUDForDeepsetCloudAPI:
             headers={
                 "Accept": "application/json",
                 "Authorization": f"Bearer {unit_config.api_key}",
+                "X-Client-Source": "deepset-cloud-sdk",
             },
             timeout=123,
         )
@@ -132,6 +136,7 @@ class TestCRUDForDeepsetCloudAPI:
             headers={
                 "Accept": "application/json",
                 "Authorization": f"Bearer {unit_config.api_key}",
+                "X-Client-Source": "deepset-cloud-sdk",
             },
             timeout=123,
         )


### PR DESCRIPTION
Based on https://github.com/deepset-ai/haystack-hub-api/pull/3015 and for https://github.com/deepset-ai/haystack-hub-api/issues/2432.

Adding a header to all request to check in the product metrics where our calls are coming from.