### PR TITLE
fix: retry for read error

### DIFF
--- a/deepset_cloud_sdk/__about__.py
+++ b/deepset_cloud_sdk/__about__.py
@@ -1,3 +1,3 @@
 """This file defines the package version."""
 
-__version__ = "0.0.20"
+__version__ = "0.0.21"

--- a/deepset_cloud_sdk/_api/deepset_cloud_api.py
+++ b/deepset_cloud_sdk/_api/deepset_cloud_api.py
@@ -69,7 +69,7 @@ class DeepsetCloudAPI:
             yield cls(config, client)
 
     @retry(
-        retry=retry_if_exception_type((httpx.ReadTimeout, httpx.ReadError)),
+        retry=retry_if_exception_type(httpx.RequestError),
         stop=stop_after_attempt(3),
         wait=wait_fixed(1),
         reraise=True,

--- a/deepset_cloud_sdk/_api/deepset_cloud_api.py
+++ b/deepset_cloud_sdk/_api/deepset_cloud_api.py
@@ -7,6 +7,7 @@ from typing import Any, AsyncGenerator, Callable, Dict, Optional
 import httpx
 import structlog
 from httpx import Response
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from deepset_cloud_sdk._api.config import CommonConfig
 
@@ -67,6 +68,12 @@ class DeepsetCloudAPI:
         async with httpx.AsyncClient() as client:
             yield cls(config, client)
 
+    @retry(
+        retry=retry_if_exception_type((httpx.ReadTimeout, httpx.ReadError)),
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(1),
+        reraise=True,
+    )
     async def get(
         self, workspace_name: str, endpoint: str, params: Optional[Dict[str, Any]] = None, timeout_s: int = 20
     ) -> Response:

--- a/tests/unit/api/test_deepset_cloud_api.py
+++ b/tests/unit/api/test_deepset_cloud_api.py
@@ -66,6 +66,31 @@ class TestCRUDForDeepsetCloudAPI:
             timeout=123,
         )
 
+    async def test_get_retry(
+        self, deepset_cloud_api: DeepsetCloudAPI, unit_config: CommonConfig, mocked_client: Mock
+    ) -> None:
+        mocked_client.get.side_effect = [
+            httpx.ReadTimeout(message="read timeout"),
+            httpx.ReadError(message="read error"),
+            httpx.Response(status_code=codes.OK, json={"test": "test"}),
+        ]
+
+        result = await deepset_cloud_api.get("default", "endpoint", params={"param_key": "param_value"}, timeout_s=123)
+        assert result.status_code == codes.OK
+        assert result.json() == {"test": "test"}
+        assert mocked_client.get.call_count == 3
+
+        mocked_client.get.assert_called_with(
+            "https://fake.dc.api/api/v1/workspaces/default/endpoint",
+            params={"param_key": "param_value"},
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {unit_config.api_key}",
+                "X-Client-Source": "deepset-cloud-sdk",
+            },
+            timeout=123,
+        )
+
     async def test_post(
         self, deepset_cloud_api: DeepsetCloudAPI, unit_config: CommonConfig, mocked_client: Mock
     ) -> None:

--- a/tests/unit/api/test_deepset_cloud_api.py
+++ b/tests/unit/api/test_deepset_cloud_api.py
@@ -71,7 +71,7 @@ class TestCRUDForDeepsetCloudAPI:
     ) -> None:
         mocked_client.get.side_effect = [
             httpx.ReadTimeout(message="read timeout"),
-            httpx.ReadError(message="read error"),
+            httpx.RequestError(message="read error"),
             httpx.Response(status_code=codes.OK, json={"test": "test"}),
         ]
 

--- a/tests/unit/api/test_deepset_cloud_api.py
+++ b/tests/unit/api/test_deepset_cloud_api.py
@@ -91,6 +91,29 @@ class TestCRUDForDeepsetCloudAPI:
             timeout=123,
         )
 
+    async def test_get_with_not_covered_retry_exception(
+        self, deepset_cloud_api: DeepsetCloudAPI, unit_config: CommonConfig, mocked_client: Mock
+    ) -> None:
+        class CustomException(Exception):
+            pass
+
+        mocked_client.get.side_effect = [
+            CustomException(),
+        ]
+        with pytest.raises(CustomException):
+            await deepset_cloud_api.get("default", "endpoint", params={"param_key": "param_value"}, timeout_s=123)
+
+    async def test_get_retry_with_exception(
+        self, deepset_cloud_api: DeepsetCloudAPI, unit_config: CommonConfig, mocked_client: Mock
+    ) -> None:
+        mocked_client.get.side_effect = [
+            httpx.ReadTimeout(message="read timeout"),
+            httpx.RequestError(message="read error"),
+            httpx.RequestError(message="read error"),
+        ]
+        with pytest.raises(httpx.RequestError):
+            await deepset_cloud_api.get("default", "endpoint", params={"param_key": "param_value"}, timeout_s=123)
+
     async def test_post(
         self, deepset_cloud_api: DeepsetCloudAPI, unit_config: CommonConfig, mocked_client: Mock
     ) -> None:


### PR DESCRIPTION
### Related Issues

- hotfix

### Proposed Changes?
- add retry for read errors for get requests to deepset cloud api 

### How did you test it?
- unit tests

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
