### PR TITLE
fix: drop old warning for file limit on workspace

### DIFF
--- a/deepset_cloud_sdk/__about__.py
+++ b/deepset_cloud_sdk/__about__.py
@@ -1,3 +1,3 @@
 """This file defines the package version."""
 
-__version__ = "0.0.23"
+__version__ = "0.0.24"

--- a/deepset_cloud_sdk/workflows/sync_client/files.py
+++ b/deepset_cloud_sdk/workflows/sync_client/files.py
@@ -167,8 +167,6 @@ def list_files(
 ) -> Generator[List[File], None, None]:
     """List files in deepset Cloud.
 
-    WARNING: This only works for workspaces with up to 1000 files.
-
     :param api_key: deepset Cloud API key to use for authentication.
     :param api_url: API URL to use for authentication.
     :param workspace_name: Name of the workspace to list the files from.
@@ -205,8 +203,6 @@ def list_upload_sessions(
     timeout_s: int = 300,
 ) -> Generator[List[UploadSessionDetail], None, None]:
     """List files in deepset Cloud.
-
-    WARNING: This only works for workspaces with up to 1000 files.
 
     :param api_key: deepset Cloud API key to use for authentication.
     :param api_url: API URL to use for authentication.


### PR DESCRIPTION
### Related Issues

- hotfix

### Proposed Changes?
- delete wrong warning

### How did you test it?
- not required
