### PR TITLE
ci: publish only on release tag publish + streamline workflow triggering

### DIFF
--- a/.github/actions/integration_tests/action.yml
+++ b/.github/actions/integration_tests/action.yml
@@ -2,7 +2,7 @@ name: 'Integration Tests'
 description: 'Runs the Integration tests '
 
 inputs:
-  TEST_API_KEY:
+  API_KEY:
     description: 'The API_KEY for deepset Cloud'
     required: true
   API_URL:
@@ -23,4 +23,4 @@ runs:
     - name: Run SDK Tests
       shell: bash
       run: |
-        API_KEY=${{inputs.TEST_API_KEY}} API_URL=${{inputs.API_URL}}  hatch run test:integration
+        API_KEY=${{inputs.API_KEY}} API_URL=${{inputs.API_URL}}  hatch run test:integration

--- a/.github/actions/integration_tests/action.yml
+++ b/.github/actions/integration_tests/action.yml
@@ -2,13 +2,12 @@ name: 'Integration Tests'
 description: 'Runs the Integration tests '
 
 inputs:
-  API_KEY:
+  TEST_API_KEY:
     description: 'The API_KEY for deepset Cloud'
     required: true
   API_URL:
     description: 'The API_URL for deepset Cloud'
     required: true
-
 
 outputs: {}
 runs:
@@ -24,4 +23,4 @@ runs:
     - name: Run SDK Tests
       shell: bash
       run: |
-        API_KEY=${{inputs.API_KEY}} API_URL=${{inputs.API_URL}}  hatch run test:integration
+        API_KEY=${{inputs.TEST_API_KEY}} API_URL=${{inputs.API_URL}}  hatch run test:integration

--- a/.github/workflows/continuous-deployment-dev.yml
+++ b/.github/workflows/continuous-deployment-dev.yml
@@ -8,9 +8,6 @@ on:
         default: https://api.dev.cloud.dpst.dev/api/v1
         type: string
 
-env:
-  HATCH_VERSION: "v1.7.0" # keep in sync with deploy.yml
-
 jobs:
   tests:
     name: Tests
@@ -21,4 +18,4 @@ jobs:
         uses: ./.github/actions/integration_tests
         with:
           API_KEY: "${{secrets.API_KEY}}"
-          API_URL: "${{env.API_URL}}"
+          API_URL: "${{inputs.API_URL}}"

--- a/.github/workflows/continuous-deployment-dev.yml
+++ b/.github/workflows/continuous-deployment-dev.yml
@@ -22,4 +22,4 @@ jobs:
         uses: ./.github/actions/integration_tests
         with:
           API_KEY: "${{secrets.API_KEY}}"
-          API_URL: "${{inputs.API_URL}}"
+          API_URL: "${{inputs.api_url}}"

--- a/.github/workflows/continuous-deployment-dev.yml
+++ b/.github/workflows/continuous-deployment-dev.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix/dev-api-url-cd
     tags:
       - "*"
 
@@ -23,8 +24,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set API URL
+        run: |-
+          echo "API_URL=$(
+          if [ ! -z ${{ inputs.api_url }} ]; then
+            echo ${{ inputs.api_url }}
+          else
+            echo "https://api.dev.cloud.dpst.dev/api/v1"
+          fi
+          )" >> $GITHUB_ENV
       - name: Run integration tests
         uses: ./.github/actions/integration_tests
         with:
           API_KEY: "${{secrets.API_KEY}}"
-          API_URL: "${{inputs.api_url}}"
+          API_URL: "${{env.API_URL}}"

--- a/.github/workflows/continuous-deployment-dev.yml
+++ b/.github/workflows/continuous-deployment-dev.yml
@@ -8,6 +8,9 @@ on:
         default: https://api.dev.cloud.dpst.dev/api/v1
         type: string
 
+env:
+  HATCH_VERSION: "v1.7.0" # keep in sync with deploy.yml
+
 jobs:
   tests:
     name: Tests

--- a/.github/workflows/continuous-deployment-dev.yml
+++ b/.github/workflows/continuous-deployment-dev.yml
@@ -1,12 +1,6 @@
 name: CD - Dev Integration Tests
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "*"
-
   workflow_dispatch:
     inputs:
       api_url:
@@ -23,15 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set API URL
-        run: |-
-          echo "API_URL=$(
-          if [ ! -z ${{ inputs.api_url }} ]; then
-            echo ${{ inputs.api_url }}
-          else
-            echo "https://api.dev.cloud.dpst.dev/api/v1"
-          fi
-          )" >> $GITHUB_ENV
       - name: Run integration tests
         uses: ./.github/actions/integration_tests
         with:

--- a/.github/workflows/continuous-deployment-dev.yml
+++ b/.github/workflows/continuous-deployment-dev.yml
@@ -7,6 +7,7 @@ on:
         required: true
         default: https://api.dev.cloud.dpst.dev/api/v1
         type: string
+        description: "The API URL for the test run"
 
 env:
   HATCH_VERSION: "v1.7.0" # keep in sync with deploy.yml

--- a/.github/workflows/continuous-deployment-dev.yml
+++ b/.github/workflows/continuous-deployment-dev.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/dev-api-url-cd
     tags:
       - "*"
 

--- a/.github/workflows/continuous-deployment-prod.yml
+++ b/.github/workflows/continuous-deployment-prod.yml
@@ -3,11 +3,7 @@ name: CD - Prod Integration Tests
 on:
   workflow_dispatch:
 
-env:
-  HATCH_VERSION: "v1.7.0" # keep in sync with deploy.yml
-
 jobs:
-
   tests:
     name: Tests
     environment: PROD

--- a/.github/workflows/continuous-deployment-prod.yml
+++ b/.github/workflows/continuous-deployment-prod.yml
@@ -1,12 +1,6 @@
 name: CD - Prod Integration Tests
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "*"
-
   workflow_dispatch:
 
 env:

--- a/.github/workflows/continuous-deployment-prod.yml
+++ b/.github/workflows/continuous-deployment-prod.yml
@@ -3,6 +3,9 @@ name: CD - Prod Integration Tests
 on:
   workflow_dispatch:
 
+env:
+  HATCH_VERSION: "v1.7.0" # keep in sync with deploy.yml
+
 jobs:
   tests:
     name: Tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -102,6 +102,8 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     environment: test
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -141,7 +141,7 @@ jobs:
   integration_tests_for_deploy:
     name: Integration Tests for deployment
     if: github.event_name == 'release'
-    environment: ${{ github.environment.inputs.deployment_env }}
+    environment: ${{ github.event.inputs.deployment_env }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -124,7 +124,6 @@ jobs:
   # we are using the "automated-tests" organization with predefined users and workspaces
   integration_tests:
     name: Integration Tests (CI)
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
     environment: test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -122,23 +122,9 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ github.token }}
 
-  # Integration tests are running against the dev environment
-  # the API_KEY is stored as a secret in the repository
+  # the API_KEYs are stored as a secret in the repository
   # we are using the "automated-tests" organization with predefined users and workspaces
   integration_tests:
-    name: Integration Tests (CI)
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
-    environment: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run integration tests
-        uses: ./.github/actions/integration_tests
-        with:
-          API_KEY: "${{secrets.API_KEY}}"
-          API_URL: "https://api.dev.cloud.dpst.dev/api/v1"
-
-  integration_tests_for_deploy:
     name: Integration Tests for deployment
     environment: ${{ github.event.inputs.deployment_env }}
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,9 +10,6 @@ on:
       api_url:
         required: true
         type: string
-      deployment_env:
-        required: true
-        type: string
     secrets:
       API_KEY:
         required: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,9 @@ on:
       api_url:
         required: true
         type: string
+      deployment_env:
+        required: true
+        type: string
     secrets:
       API_KEY:
         required: true
@@ -138,13 +141,14 @@ jobs:
   integration_tests_for_deploy:
     name: Integration Tests for deployment
     if: github.event_name == 'release'
+    environment: ${{ inputs.deployment_env }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Run integration tests
         uses: ./.github/actions/integration_tests
         with:
-          API_KEY: "${{secrets.TEST_API_KEY}}"
+          API_KEY: "${{secrets.API_KEY}}"
           API_URL: "${{ inputs.api_url }}"
 
   build:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -136,7 +136,7 @@ jobs:
 
   integration_tests_for_deploy:
     name: Integration Tests for deployment
-    if: github.event_name == 'workflow_call'
+    if: startsWith(github.event.ref, 'refs/tags/version-')
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_env }}
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -138,7 +138,7 @@ jobs:
   integration_tests_for_deploy:
     name: Integration Tests for deployment
     if: github.event_name == 'release'
-    environment: ${{inputs.deployment_env}}
+    environment: ${{ github.event.inputs.deployment_env }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -140,7 +140,6 @@ jobs:
 
   integration_tests_for_deploy:
     name: Integration Tests for deployment
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     environment: ${{ github.event.inputs.deployment_env }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,13 +10,12 @@ on:
       api_url:
         required: true
         type: string
-    secrets:
-      API_KEY:
+      deployment_env:
         required: true
+        type: string
 
 env:
   HATCH_VERSION: "v1.7.0" # keep in sync with deploy.yml
-  API_KEY: ${{secrets.API_KEY}}
 
 jobs:
   format-black:
@@ -116,10 +115,10 @@ jobs:
         uses: py-cov-action/python-coverage-comment-action@48708266a6e77ebf564b50d9cff2b7df9a25b458
         with:
           GITHUB_TOKEN: ${{ github.token }}
-      # Integration tests are running against the dev environment
-      # the API_KEY is stored as a secret in the repository
-      # we are using the "automated-tests" organization with predefined users and workspaces
 
+  # Integration tests are running against the dev environment
+  # the API_KEY is stored as a secret in the repository
+  # we are using the "automated-tests" organization with predefined users and workspaces
   integration_tests:
     name: Integration Tests
     if: github.event_name == 'push' || github.event_name == 'pull_request'
@@ -136,6 +135,7 @@ jobs:
     name: Integration Tests
     if: github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
+    environment: ${{ inputs.deployment_env }}
     steps:
       - uses: actions/checkout@v3
       - name: Run integration tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -141,6 +141,8 @@ jobs:
     environment: ${{ inputs.deployment_env }}
     steps:
       - uses: actions/checkout@v3
+      - name: test
+        run: echo "${{inputs.deployment_env}}, ${{github.event.inputs.deployment_env}}, ${{github.event_name}}"
       - name: Run integration tests
         if: "${{ github.event.inputs.deployment_env != '' }}"
         uses: ./.github/actions/integration_tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -141,7 +141,7 @@ jobs:
   integration_tests_for_deploy:
     name: Integration Tests for deployment
     if: github.event_name == 'release'
-    environment: ${{ inputs.deployment_env }}
+    environment: ${{ github.event.inputs.deployment_env }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -148,7 +148,7 @@ jobs:
         uses: ./.github/actions/integration_tests
         with:
           API_KEY: "${{ inputs.deployment_env == 'release' && secrets.API_KEY_PROD || secrets.API_KEY}}"
-          API_URL: "${{ inputs.api_url }}"
+          API_URL: "${{ inputs.api_url || 'https://api.dev.cloud.dpst.dev/api/v1'}}"
 
   build:
     name: Build package

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -137,7 +137,7 @@ jobs:
 
   integration_tests_for_deploy:
     name: Integration Tests for deployment
-    if: "${{ inputs.deployment_env != '' }}"
+    if: "${{ github.event.inputs.deployment_env == 'release' }}"
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_env }}
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -141,7 +141,6 @@ jobs:
   integration_tests_for_deploy:
     name: Integration Tests for deployment
     if: github.event_name == 'release'
-    environment: ${{ github.event.inputs.deployment_env }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -137,7 +137,7 @@ jobs:
 
   integration_tests_for_deploy:
     name: Integration Tests for deployment
-    if: "${{ github.event.inputs.deployment_env != '' }}"
+    if: "${{ inputs.deployment_env != '' }}"
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_env }}
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,6 +13,9 @@ on:
       deployment_env:
         required: true
         type: string
+    secrets:
+      API_KEY:
+        required: true
 
 env:
   HATCH_VERSION: "v1.7.0" # keep in sync with deploy.yml
@@ -138,7 +141,7 @@ jobs:
   integration_tests_for_deploy:
     name: Integration Tests for deployment
     if: github.event_name == 'release'
-    environment: ${{ github.event.inputs.deployment_env }}
+    environment: ${{ github.environment.inputs.deployment_env }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,9 +10,6 @@ on:
       api_url:
         required: true
         type: string
-      deployment_env:
-        required: true
-        type: string
     secrets:
       API_KEY:
         required: true
@@ -137,19 +134,6 @@ jobs:
         with:
           API_KEY: "${{secrets.API_KEY}}"
           API_URL: "https://api.dev.cloud.dpst.dev/api/v1"
-
-  integration_tests_for_deploy:
-    name: Integration Tests for deployment
-    if: github.event_name == 'release'
-    environment: ${{ github.event.inputs.deployment_env }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run integration tests
-        uses: ./.github/actions/integration_tests
-        with:
-          API_KEY: "${{secrets.API_KEY}}"
-          API_URL: "${{ inputs.api_url }}"
 
   build:
     name: Build package

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -137,7 +137,7 @@ jobs:
 
   integration_tests_for_deploy:
     name: Integration Tests for deployment
-    if: startsWith(github.event.ref, 'refs/tags/version-')
+    if: "${{ github.event.inputs.deployment_env != '' }}"
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_env }}
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -138,7 +138,6 @@ jobs:
   integration_tests_for_deploy:
     name: Integration Tests for deployment
     runs-on: ubuntu-latest
-    environment: ${{ inputs.deployment_env }}
     steps:
       - uses: actions/checkout@v3
       - name: test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -140,7 +140,7 @@ jobs:
 
   integration_tests_for_deploy:
     name: Integration Tests for deployment
-    if: github.event_name == 'release'
+    environment: ${{ github.event.inputs.deployment_env }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -137,11 +137,11 @@ jobs:
 
   integration_tests_for_deploy:
     name: Integration Tests for deployment
+    if: github.event_name == 'release'
+    environment: ${{inputs.deployment_env}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: test
-        run: echo "${{inputs.deployment_env}}, ${{github.event.inputs.deployment_env}}, ${{github.event_name}}"
       - name: Run integration tests
         uses: ./.github/actions/integration_tests
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -101,7 +101,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    environment: ${{ inputs.deployment_env }}
+    environment: test
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -123,6 +123,7 @@ jobs:
   integration_tests:
     name: Integration Tests
     if: github.event_name == 'push' || github.event_name == 'pull_request'
+    environment: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -113,6 +113,7 @@ jobs:
       - name: Run unit tests
         run: hatch run test:unit-with-cov
       - name: Coverage comment
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@48708266a6e77ebf564b50d9cff2b7df9a25b458
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -101,6 +101,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    environment: ${{ inputs.deployment_env }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -140,6 +140,7 @@ jobs:
 
   integration_tests_for_deploy:
     name: Integration Tests for deployment
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     environment: ${{ github.event.inputs.deployment_env }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Run integration tests
         uses: ./.github/actions/integration_tests
         with:
-          API_KEY: "${{secrets.API_KEY}}"
+          API_KEY: "${{ inputs.deployment_env == 'release' && secrets.API_KEY_PROD || secrets.API_KEY}}"
           API_URL: "${{ inputs.api_url }}"
 
   build:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -144,7 +144,6 @@ jobs:
       - name: test
         run: echo "${{inputs.deployment_env}}, ${{github.event.inputs.deployment_env}}, ${{github.event_name}}"
       - name: Run integration tests
-        if: "${{ github.event.inputs.deployment_env != '' }}"
         uses: ./.github/actions/integration_tests
         with:
           API_KEY: "${{secrets.API_KEY}}"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,9 @@ on:
       api_url:
         required: true
         type: string
+      deployment_env:
+        required: true
+        type: string
     secrets:
       API_KEY:
         required: true
@@ -124,6 +127,7 @@ jobs:
   # we are using the "automated-tests" organization with predefined users and workspaces
   integration_tests:
     name: Integration Tests (CI)
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     environment: test
     runs-on: ubuntu-latest
     steps:
@@ -133,6 +137,18 @@ jobs:
         with:
           API_KEY: "${{secrets.API_KEY}}"
           API_URL: "https://api.dev.cloud.dpst.dev/api/v1"
+
+  integration_tests_for_deploy:
+    name: Integration Tests for deployment
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run integration tests
+        uses: ./.github/actions/integration_tests
+        with:
+          API_KEY: "${{secrets.TEST_API_KEY}}"
+          API_URL: "${{ inputs.api_url }}"
 
   build:
     name: Build package

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -101,9 +101,8 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    environment: test
     env:
-      API_KEY: ${{ secrets.API_KEY }}
+      API_KEY: "not-a-real-api-key"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -137,12 +137,12 @@ jobs:
 
   integration_tests_for_deploy:
     name: Integration Tests for deployment
-    if: "${{ github.event.inputs.deployment_env == 'release' }}"
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_env }}
     steps:
       - uses: actions/checkout@v3
       - name: Run integration tests
+        if: "${{ github.event.inputs.deployment_env != '' }}"
         uses: ./.github/actions/integration_tests
         with:
           API_KEY: "${{secrets.API_KEY}}"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "*"
   pull_request:
   workflow_call:
+    inputs:
+      api_url:
+        required: true
+        type: string
     secrets:
       API_KEY:
         required: true
@@ -120,6 +122,7 @@ jobs:
 
   integration_tests:
     name: Integration Tests
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -128,6 +131,18 @@ jobs:
         with:
           API_KEY: "${{secrets.API_KEY}}"
           API_URL: "https://api.dev.cloud.dpst.dev/api/v1"
+
+  integration_tests_for_deploy:
+    name: Integration Tests
+    if: github.event_name == 'workflow_call'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run integration tests
+        uses: ./.github/actions/integration_tests
+        with:
+          API_KEY: "${{secrets.API_KEY}}"
+          API_URL: "${{ inputs.api_url }}"
 
   build:
     name: Build package

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -121,7 +121,7 @@ jobs:
   # the API_KEY is stored as a secret in the repository
   # we are using the "automated-tests" organization with predefined users and workspaces
   integration_tests:
-    name: Integration Tests
+    name: Integration Tests (CI)
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     environment: test
     runs-on: ubuntu-latest
@@ -134,7 +134,7 @@ jobs:
           API_URL: "https://api.dev.cloud.dpst.dev/api/v1"
 
   integration_tests_for_deploy:
-    name: Integration Tests
+    name: Integration Tests for deployment
     if: github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment_env }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 env:
   HATCH_VERSION: "v1.7.0" # keep in sync with deploy.yml

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,5 +12,5 @@ jobs:
   deploy-prod:
     uses: ./.github/workflows/deploy.yml
     with:
-      deployment_env: release
+      deployment_env: "release"
       api_url: "https://api.cloud.deepset.ai/api/v1"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -4,15 +4,10 @@ on:
   release:
     types:
       - published
-env:
-  HATCH_VERSION: "v1.7.0" # keep in sync with continuous-integration.yml
 
 jobs:
   deploy-prod:
     uses: ./.github/workflows/deploy.yml
-    environment: PROD
     with:
       deployment_env: release
       api_url: "https://api.cloud.deepset.ai/api/v1"
-    secrets:
-      API_KEY: ${{ secrets.API_KEY }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,4 +15,4 @@ jobs:
       deployment_env: "release"
       api_url: "https://api.cloud.deepset.ai/api/v1"
     secrets:
-      API_KEY: ${{ secrets.API_KEY }}
+      API_KEY: ${{ secrets.API_KEY_PROD }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,18 +1,18 @@
 name: Deploy to Prod PyPi
 
 on:
-  push:
-    branches:
-      - main
-
+  release:
+    types:
+      - published
 env:
   HATCH_VERSION: "v1.7.0" # keep in sync with continuous-integration.yml
-  API_KEY: ${{secrets.API_KEY}}
 
 jobs:
   deploy-prod:
     uses: ./.github/workflows/deploy.yml
+    environment: PROD
     with:
       deployment_env: release
+      api_url: "https://api.cloud.deepset.ai/api/v1"
     secrets:
       API_KEY: ${{ secrets.API_KEY }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,4 +15,4 @@ jobs:
       deployment_env: "release"
       api_url: "https://api.cloud.deepset.ai/api/v1"
     secrets:
-      API_KEY: ${{ secrets.API_KEY_PROD }}
+      TEST_API_KEY: ${{ secrets.API_KEY_PROD }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,3 +14,5 @@ jobs:
     with:
       deployment_env: "release"
       api_url: "https://api.cloud.deepset.ai/api/v1"
+    secrets:
+      API_KEY: ${{ secrets.API_KEY }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,5 +14,4 @@ jobs:
     with:
       deployment_env: "release"
       api_url: "https://api.cloud.deepset.ai/api/v1"
-    secrets:
-      TEST_API_KEY: ${{ secrets.API_KEY_PROD }}
+    secrets: inherit

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -5,6 +5,9 @@ on:
     types:
       - published
 
+env:
+  HATCH_VERSION: "v1.7.0" # keep in sync with deploy.yml
+
 jobs:
   deploy-prod:
     uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -6,6 +6,9 @@ on:
       - labeled
   workflow_dispatch:
 
+env:
+  HATCH_VERSION: "v1.7.0" # keep in sync with deploy.yml
+
 jobs:
   deploy-test:
     if: ${{ github.event.label.name == 'test-deploy' }}`

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -16,5 +16,4 @@ jobs:
     with:
       deployment_env: "test"
       api_url: "https://api.dev.cloud.dpst.dev/api/v1"
-    secrets:
-      TEST_API_KEY: ${{ secrets.API_KEY }}
+    secrets: inherit

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -12,3 +12,4 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       deployment_env: test
+      api_url: "https://api.dev.cloud.dpst.dev/api/v1"

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -14,5 +14,5 @@ jobs:
     if: ${{ github.event.label.name == 'test-deploy' }}`
     uses: ./.github/workflows/deploy.yml
     with:
-      deployment_env: test
+      deployment_env: "test"
       api_url: "https://api.dev.cloud.dpst.dev/api/v1"

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -17,4 +17,4 @@ jobs:
       deployment_env: "test"
       api_url: "https://api.dev.cloud.dpst.dev/api/v1"
     secrets:
-      API_KEY: ${{ secrets.API_KEY }}
+      TEST_API_KEY: ${{ secrets.API_KEY }}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -16,3 +16,5 @@ jobs:
     with:
       deployment_env: "test"
       api_url: "https://api.dev.cloud.dpst.dev/api/v1"
+    secrets:
+      API_KEY: ${{ secrets.API_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,6 @@ jobs:
     uses: ./.github/workflows/continuous-integration.yml
     with:
       api_url: ${{ inputs.api_url }}
-      deployment_env: ${{ inputs.deployment_env }}
     secrets:
       API_KEY: ${{ secrets.API_KEY }}
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/continuous-integration.yml
     with:
       api_url: ${{ inputs.api_url }}
-      deployment_env: ${{ github.event.inputs.deployment_env }}
+      deployment_env: ${{ inputs.deployment_env }}
   build-and-deploy:
     needs: ci
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,6 @@ on:
         required: true
         default: https://api.dev.cloud.dpst.dev/api/v1
         type: string
-    secrets:
-      TEST_API_KEY:
-        required: true
 
 permissions:
   id-token: write
@@ -25,8 +22,8 @@ jobs:
     uses: ./.github/workflows/continuous-integration.yml
     with:
       api_url: ${{ inputs.api_url }}
-    secrets:
-      API_KEY: ${{ secrets.TEST_API_KEY }}
+      deployment_env: ${{ inputs.deployment_env }}
+    secrets: inherit
   build-and-deploy:
     needs: ci
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,11 @@ on:
       deployment_env:
         required: true
         type: string
+      api_url:
+        required: true
+        default: https://api.dev.cloud.dpst.dev/api/v1
+        type: string
+
     secrets:
       API_KEY:
         required: true
@@ -19,6 +24,8 @@ env:
 jobs:
   ci:
     uses: ./.github/workflows/continuous-integration.yml
+    with:
+      api_url: ${{ inputs.api_url }}
     secrets:
       API_KEY: ${{ secrets.API_KEY }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,11 @@ jobs:
     uses: ./.github/workflows/continuous-integration.yml
     with:
       api_url: ${{ inputs.api_url }}
-      deployment_env: ${{ inputs.deployment_env }}
+      deployment_env: ${{ github.event.inputs.deployment_env }}
   build-and-deploy:
     needs: ci
     runs-on: ubuntu-latest
-    environment: ${{inputs.deployment_env}}
+    environment: ${{github.event.inputs.deployment_env}}
     env:
       pypi: ${{ vars.PYPI_URL }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,7 @@ jobs:
     uses: ./.github/workflows/continuous-integration.yml
     with:
       api_url: ${{ inputs.api_url }}
-    secrets:
-      API_KEY: ${{ secrets.API_KEY }}
-
+      deployment_env: ${{ inputs.deployment_env }}
   build-and-deploy:
     needs: ci
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ on:
         required: true
         default: https://api.dev.cloud.dpst.dev/api/v1
         type: string
+    secrets:
+      API_KEY:
+        required: true
 
 permissions:
   id-token: write
@@ -22,7 +25,9 @@ jobs:
     uses: ./.github/workflows/continuous-integration.yml
     with:
       api_url: ${{ inputs.api_url }}
-      deployment_env: ${{ inputs.deployment_env }}
+      deployment_env: ${{ inputs.deplopyment_env }}
+    secrets:
+      API_KEY: ${{ secrets.API_KEY }}
   build-and-deploy:
     needs: ci
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
         default: https://api.dev.cloud.dpst.dev/api/v1
         type: string
     secrets:
-      API_KEY:
+      TEST_API_KEY:
         required: true
 
 permissions:
@@ -26,7 +26,7 @@ jobs:
     with:
       api_url: ${{ inputs.api_url }}
     secrets:
-      API_KEY: ${{ secrets.API_KEY }}
+      API_KEY: ${{ secrets.TEST_API_KEY }}
   build-and-deploy:
     needs: ci
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/continuous-integration.yml
     with:
       api_url: ${{ inputs.api_url }}
-      deployment_env: ${{ inputs.deplopyment_env }}
+      deployment_env: ${{ inputs.deployment_env }}
     secrets:
       API_KEY: ${{ secrets.API_KEY }}
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ on:
         required: true
         default: https://api.dev.cloud.dpst.dev/api/v1
         type: string
+
 permissions:
   id-token: write
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,11 +10,6 @@ on:
         required: true
         default: https://api.dev.cloud.dpst.dev/api/v1
         type: string
-
-    secrets:
-      API_KEY:
-        required: true
-
 permissions:
   id-token: write
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ hatch run code-quality:hooks
 ## CI
 Code quality checks, unit tests, and integration tests (against dev) are performed on the creation of a PR, and subsequent pushes for that PR.
 Code quality checks, unit tests, and integration tests (against dev) are performed on a push to main.
+Integration tests are triggered whenever the e2e tests are triggered (environment will be dependent on e2e tests)
 Code quality checks, unit tests, and integration tests (against prod) are performed on the publishing of a release tag.
 
 ## Deploy to test PyPi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,18 @@ pip install hatch=="v1.7.0"
 hatch run code-quality:hooks
 ```
 
+## CI
+Code quality checks, unit tests, and integration tests (against dev) are performed on the creation of a PR, and subsequent pushes for that PR.
+Code quality checks, unit tests, and integration tests (against dev) are performed on a push to main.
+Code quality checks, unit tests, and integration tests (against prod) are performed on the publishing of a release tag.
+
 ## Deploy to test PyPi
 
 When you create a PR in the deepset-cloud-sdk repository, add the 'test-deploy' label to trigger deployment to the test PyPi repository.
+
+## Publishing to PyPi
+
+To publish a new version of the SDK you will need to create and publish a new release tag.
 
 
 ## Software design


### PR DESCRIPTION
### Related Issues

**The CI/CD flow is updated as follows:**
Code quality checks, unit tests, and integration tests (against dev) are performed on the creation of a PR, and subsequent pushes for that PR.
Code quality checks, unit tests, and integration tests (against dev) are performed on a push to main.
Code quality checks, unit tests, and integration tests (against prod) are performed on the publishing of a release tag.


### Proposed Changes?

set API_URL for dev in push dispatch for workflow

### How did you test it?

https://github.com/deepset-ai/deepset-cloud-sdk/actions/runs/5339520410/jobs/9678301125

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [x] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
