### PR TITLE
fix: Fixed name of param for filtering when listing files

### DIFF
--- a/deepset_cloud_sdk/_api/files.py
+++ b/deepset_cloud_sdk/_api/files.py
@@ -108,7 +108,7 @@ class FilesAPI:
 
         # odata odata_filter for file meta
         if odata_filter:
-            params["odata_filter"] = odata_filter
+            params["filter"] = odata_filter
 
         response = await self._deepset_cloud_api.get(workspace_name, "files", params=params)
         assert response.status_code == codes.OK, f"Failed to list files: {response.text}"

--- a/deepset_cloud_sdk/workflows/sync_client/files.py
+++ b/deepset_cloud_sdk/workflows/sync_client/files.py
@@ -51,6 +51,9 @@ def upload_file_paths(
     :param api_key: deepset Cloud API key to use for authentication.
     :param api_url: API URL to use for authentication.
     :param workspace_name: Name of the workspace to upload the files to. It uses the workspace from the .ENV file by default.
+    :param write_mode: The write mode determines how to handle uploading a file if it's already in the workspace.
+        Your options are: keep the file with the same name, make the request fail if a file with the same name already
+        exists, or overwrite the file. If you choose to overwrite, all files with the same name are overwritten.
     :param blocking: Whether to wait for the files to be uploaded and listed in deepset Cloud.
     :param timeout_s: Timeout in seconds for the `blocking` parameter`.
     :param show_progress: Shows the upload progress.
@@ -87,10 +90,13 @@ def upload(
     :param api_key: deepset Cloud API key to use for authentication.
     :param api_url: API URL to use for authentication.
     :param workspace_name: Name of the workspace to upload the files to. It uses the workspace from the .ENV file by default.
+    :param write_mode: The write mode determines how to handle uploading a file if it's already in the workspace.
+        Your options are: keep the file with the same name, make the request fail if a file with the same name already
+        exists, or overwrite the file. If you choose to overwrite, all files with the same name are overwritten.
     :param blocking: Whether to wait for the files to be uploaded and displayed in deepset Cloud.
     :param timeout_s: Timeout in seconds for the `blocking` parameter.
     :param show_progress: Shows the upload progress.
-    :recursive: Uploads files from subfolders as well.
+    :param recursive: Uploads files from subfolders as well.
     """
     asyncio.run(
         async_upload(


### PR DESCRIPTION
### Related Issues

- fixes #N/A

### Proposed Changes?

 <!--- In case of a bug: Describe what caused the issue and how you solved it-->
- Updated the param name from `odata_filter` to `filter` to match the name shown in the API [docs](https://docs.cloud.deepset.ai/reference/list_files_api_v1_workspaces__workspace_name__files_get)

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
