### PR TITLE
fix: flaky e2e test

### DIFF
--- a/tests/integration/service/test_integration_files_service.py
+++ b/tests/integration/service/test_integration_files_service.py
@@ -54,6 +54,7 @@ class TestListFilesService:
             async for file_batch in file_service.list_all(
                 workspace_name="sdk_read",
                 batch_size=11,
+                timeout_s=120,
             ):
                 file_batches.append(file_batch)
 


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/deepset-cloud-sdk/issues/76

### Proposed Changes?
- increase timeout for list files api to 120 seconds

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [x] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [x] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
