### PR TITLE
feat: return upload summary

### DIFF
--- a/deepset_cloud_sdk/__about__.py
+++ b/deepset_cloud_sdk/__about__.py
@@ -1,3 +1,3 @@
 """This file defines the package version."""
 
-__version__ = "0.0.29"
+__version__ = "0.0.30"

--- a/deepset_cloud_sdk/_service/files_service.py
+++ b/deepset_cloud_sdk/_service/files_service.py
@@ -307,7 +307,7 @@ class FilesService:
         blocking: bool = True,
         timeout_s: int = 300,
         show_progress: bool = True,
-    ) -> S3UploadSummary:
+    ) -> S3UploadSummary:  # noqa
         """
         Upload a list of raw texts to a workspace using upload sessions. This method accepts a list of DeepsetCloudFiles
         which contain raw text, file name, and optional metadata.

--- a/deepset_cloud_sdk/_service/files_service.py
+++ b/deepset_cloud_sdk/_service/files_service.py
@@ -23,7 +23,7 @@ from deepset_cloud_sdk._api.upload_sessions import (
     UploadSessionStatus,
     WriteMode,
 )
-from deepset_cloud_sdk._s3.upload import S3
+from deepset_cloud_sdk._s3.upload import S3, S3UploadSummary
 from deepset_cloud_sdk.models import DeepsetCloudFile
 
 logger = structlog.get_logger(__name__)
@@ -128,7 +128,7 @@ class FilesService:
         blocking: bool = True,
         timeout_s: int = 300,
         show_progress: bool = True,
-    ) -> None:
+    ) -> S3UploadSummary:
         """Upload a list of files to a workspace.
 
         Upload a list of files to a selected workspace using upload sessions. It first uploads the files to S3 and then lists them in deepset Cloud.
@@ -167,7 +167,7 @@ class FilesService:
                 timeout_s=timeout_s,
                 show_progress=show_progress,
             )
-        return upload_summary 
+        return upload_summary
 
     @staticmethod
     def _get_file_paths(paths: List[Path], recursive: bool = False) -> List[Path]:
@@ -264,7 +264,7 @@ class FilesService:
         timeout_s: int = 300,
         show_progress: bool = True,
         recursive: bool = False,
-    ) -> None:
+    ) -> S3UploadSummary:
         """Upload a list of file or folder paths to a workspace.
 
         Upload files to a selected workspace using upload sessions. It first uploads the files to S3 and then lists them in deepset Cloud.
@@ -290,7 +290,7 @@ class FilesService:
         else:
             file_paths = self._preprocess_paths(paths, recursive=recursive)
 
-        await self.upload_file_paths(
+        return await self.upload_file_paths(
             workspace_name=workspace_name,
             file_paths=file_paths,
             write_mode=write_mode,
@@ -307,7 +307,7 @@ class FilesService:
         blocking: bool = True,
         timeout_s: int = 300,
         show_progress: bool = True,
-    ) -> None:  # noqa
+    ) -> S3UploadSummary:
         """
         Upload a list of raw texts to a workspace using upload sessions. This method accepts a list of DeepsetCloudFiles
         which contain raw text, file name, and optional metadata.

--- a/deepset_cloud_sdk/_service/files_service.py
+++ b/deepset_cloud_sdk/_service/files_service.py
@@ -167,6 +167,7 @@ class FilesService:
                 timeout_s=timeout_s,
                 show_progress=show_progress,
             )
+        return upload_summary 
 
     @staticmethod
     def _get_file_paths(paths: List[Path], recursive: bool = False) -> List[Path]:
@@ -344,6 +345,7 @@ class FilesService:
                 timeout_s=timeout_s,
                 show_progress=show_progress,
             )
+        return upload_summary
 
     async def list_all(
         self,

--- a/deepset_cloud_sdk/workflows/async_client/files.py
+++ b/deepset_cloud_sdk/workflows/async_client/files.py
@@ -18,6 +18,7 @@ from deepset_cloud_sdk._api.upload_sessions import (
     UploadSessionStatus,
     WriteMode,
 )
+from deepset_cloud_sdk._s3.upload import S3UploadSummary
 from deepset_cloud_sdk._service.files_service import DeepsetCloudFile, FilesService
 
 
@@ -158,7 +159,7 @@ async def upload(
     timeout_s: int = 300,
     show_progress: bool = True,
     recursive: bool = False,
-) -> None:
+) -> S3UploadSummary:
     """Upload a folder to deepset Cloud.
 
     :param paths: Path to the folder to upload. If the folder contains unsupported files, they're skipped.
@@ -177,7 +178,7 @@ async def upload(
     :param recursive: Uploads files from subdirectories as well.
     """
     async with FilesService.factory(_get_config(api_key=api_key, api_url=api_url)) as file_service:
-        await file_service.upload(
+        return await file_service.upload(
             workspace_name=workspace_name,
             paths=paths,
             write_mode=write_mode,
@@ -215,7 +216,7 @@ async def upload_texts(
     :param show_progress: Shows the upload progress.
     """
     async with FilesService.factory(_get_config(api_key=api_key, api_url=api_url)) as file_service:
-        await file_service.upload_texts(
+        return await file_service.upload_texts(
             workspace_name=workspace_name,
             files=files,
             write_mode=write_mode,

--- a/deepset_cloud_sdk/workflows/async_client/files.py
+++ b/deepset_cloud_sdk/workflows/async_client/files.py
@@ -118,37 +118,6 @@ async def get_upload_session(
         )
 
 
-async def upload_file_paths(
-    file_paths: List[Path],
-    api_key: Optional[str] = None,
-    api_url: Optional[str] = None,
-    workspace_name: str = DEFAULT_WORKSPACE_NAME,
-    write_mode: WriteMode = WriteMode.KEEP,
-    blocking: bool = True,
-    timeout_s: int = 300,
-    show_progress: bool = True,
-) -> None:
-    """Upload files to deepset Cloud.
-
-    :param file_paths: List of file paths to upload.
-    :param api_key: deepset Cloud API key to use for authentication.
-    :param api_url: API URL to use for authentication.
-    :param workspace_name: Name of the workspace to upload the files to. It uses the workspace from the .ENV file by default.
-    :param blocking: Whether to wait for the upload to finish.
-    :param timeout_s: Timeout in seconds for the upload.
-    :param show_progress: Shows the upload progress.
-    """
-    async with FilesService.factory(_get_config(api_key=api_key, api_url=api_url)) as file_service:
-        await file_service.upload_file_paths(
-            workspace_name=workspace_name,
-            file_paths=file_paths,
-            write_mode=write_mode,
-            blocking=blocking,
-            timeout_s=timeout_s,
-            show_progress=show_progress,
-        )
-
-
 async def upload(
     paths: List[Path],
     api_key: Optional[str] = None,

--- a/deepset_cloud_sdk/workflows/async_client/files.py
+++ b/deepset_cloud_sdk/workflows/async_client/files.py
@@ -198,7 +198,7 @@ async def upload_texts(
     blocking: bool = True,
     timeout_s: int = 300,
     show_progress: bool = True,
-) -> None:
+) -> S3UploadSummary:
     """Upload raw texts to deepset Cloud.
 
     :param files: List of DeepsetCloudFiles to upload.

--- a/deepset_cloud_sdk/workflows/sync_client/files.py
+++ b/deepset_cloud_sdk/workflows/sync_client/files.py
@@ -13,6 +13,7 @@ from deepset_cloud_sdk._api.upload_sessions import (
     UploadSessionStatus,
     WriteMode,
 )
+from deepset_cloud_sdk._s3.upload import S3UploadSummary
 from deepset_cloud_sdk._service.files_service import DeepsetCloudFile
 from deepset_cloud_sdk.workflows.async_client.files import (
     get_upload_session as async_get_upload_session,
@@ -25,51 +26,11 @@ from deepset_cloud_sdk.workflows.async_client.files import (
 )
 from deepset_cloud_sdk.workflows.async_client.files import upload as async_upload
 from deepset_cloud_sdk.workflows.async_client.files import (
-    upload_file_paths as async_upload_file_paths,
-)
-from deepset_cloud_sdk.workflows.async_client.files import (
     upload_texts as async_upload_texts,
 )
 from deepset_cloud_sdk.workflows.sync_client.utils import iter_over_async
 
 logger = structlog.get_logger(__name__)
-
-
-def upload_file_paths(
-    file_paths: List[Path],
-    api_key: Optional[str] = None,
-    api_url: Optional[str] = None,
-    workspace_name: str = DEFAULT_WORKSPACE_NAME,
-    write_mode: WriteMode = WriteMode.KEEP,
-    blocking: bool = True,
-    timeout_s: int = 300,
-    show_progress: bool = True,
-) -> None:
-    """Upload files to deepset Cloud.
-
-    :param file_paths: List of file paths to upload.
-    :param api_key: deepset Cloud API key to use for authentication.
-    :param api_url: API URL to use for authentication.
-    :param workspace_name: Name of the workspace to upload the files to. It uses the workspace from the .ENV file by default.
-    :param write_mode: The write mode determines how to handle uploading a file if it's already in the workspace.
-        Your options are: keep the file with the same name, make the request fail if a file with the same name already
-        exists, or overwrite the file. If you choose to overwrite, all files with the same name are overwritten.
-    :param blocking: Whether to wait for the files to be uploaded and listed in deepset Cloud.
-    :param timeout_s: Timeout in seconds for the `blocking` parameter`.
-    :param show_progress: Shows the upload progress.
-    """
-    asyncio.run(
-        async_upload_file_paths(
-            file_paths=file_paths,
-            api_key=api_key,
-            api_url=api_url,
-            workspace_name=workspace_name,
-            write_mode=write_mode,
-            blocking=blocking,
-            timeout_s=timeout_s,
-            show_progress=show_progress,
-        )
-    )
 
 
 def upload(
@@ -82,7 +43,7 @@ def upload(
     timeout_s: int = 300,
     show_progress: bool = True,
     recursive: bool = False,
-) -> None:
+) -> S3UploadSummary:
     """Upload a folder to deepset Cloud.
 
     :param paths: Path to the folder to upload. If the folder contains unsupported file types, they're skipped.
@@ -98,7 +59,7 @@ def upload(
     :param show_progress: Shows the upload progress.
     :param recursive: Uploads files from subfolders as well.
     """
-    asyncio.run(
+    return asyncio.run(
         async_upload(
             paths=paths,
             api_key=api_key,
@@ -122,7 +83,7 @@ def upload_texts(
     blocking: bool = True,
     timeout_s: int = 300,
     show_progress: bool = True,
-) -> None:
+) -> S3UploadSummary:
     """Upload texts to deepset Cloud.
 
     :param files: List of DeepsetCloudFiles to upload.
@@ -138,7 +99,7 @@ def upload_texts(
     :param timeout_s: Timeout in seconds for the `blocking` parameter.
     :param show_progress: Shows the upload progress.
     """
-    asyncio.run(
+    return asyncio.run(
         async_upload_texts(
             files=files,
             api_key=api_key,

--- a/tests/integration/service/test_integration_files_service.py
+++ b/tests/integration/service/test_integration_files_service.py
@@ -20,13 +20,17 @@ class TestUploadsFileService:
         async with FilesService.factory(integration_config) as file_service:
             timeout = 120 if "dev.cloud.dpst.dev" in integration_config.api_url else 300
 
-            await file_service.upload(
+            result = await file_service.upload(
                 workspace_name=workspace_name,
                 paths=[Path("./tests/test_data/msmarco.10")],
                 blocking=True,
                 write_mode=WriteMode.KEEP,
                 timeout_s=timeout,
             )
+            assert result.total_files == 10
+            assert result.successful_upload_count == 10
+            assert result.failed_upload_count == 0
+            assert len(result.failed) == 0
 
     async def test_upload_texts(self, integration_config: CommonConfig, workspace_name: str) -> None:
         async with FilesService.factory(integration_config) as file_service:
@@ -37,13 +41,17 @@ class TestUploadsFileService:
                 DeepsetCloudFile("file4", "file4.txt", {"which": 4}),
                 DeepsetCloudFile("file5", "file5.txt", {"which": 5}),
             ]
-            await file_service.upload_texts(
+            result = await file_service.upload_texts(
                 workspace_name=workspace_name,
                 files=files,
                 blocking=True,
                 write_mode=WriteMode.KEEP,
                 timeout_s=120,
             )
+            assert result.total_files == 5
+            assert result.successful_upload_count == 5
+            assert result.failed_upload_count == 0
+            assert len(result.failed) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/integration/service/test_integration_files_service.py
+++ b/tests/integration/service/test_integration_files_service.py
@@ -27,8 +27,8 @@ class TestUploadsFileService:
                 write_mode=WriteMode.KEEP,
                 timeout_s=timeout,
             )
-            assert result.total_files == 10
-            assert result.successful_upload_count == 10
+            assert result.total_files == 20
+            assert result.successful_upload_count == 20
             assert result.failed_upload_count == 0
             assert len(result.failed) == 0
 
@@ -48,8 +48,8 @@ class TestUploadsFileService:
                 write_mode=WriteMode.KEEP,
                 timeout_s=120,
             )
-            assert result.total_files == 5
-            assert result.successful_upload_count == 5
+            assert result.total_files == 10
+            assert result.successful_upload_count == 10
             assert result.failed_upload_count == 0
             assert len(result.failed) == 0
 

--- a/tests/unit/service/test_files_service.py
+++ b/tests/unit/service/test_files_service.py
@@ -192,7 +192,7 @@ class TestUploadsFileService:
                     finished_files=1,
                 ),
             )
-            await file_service.upload_texts(
+            result = await file_service.upload_texts(
                 workspace_name="test_workspace",
                 files=files,
                 write_mode=WriteMode.OVERWRITE,

--- a/tests/unit/service/test_files_service.py
+++ b/tests/unit/service/test_files_service.py
@@ -19,6 +19,7 @@ from deepset_cloud_sdk._api.upload_sessions import (
     UploadSessionWriteModeEnum,
     WriteMode,
 )
+from deepset_cloud_sdk._s3.upload import S3UploadSummary
 from deepset_cloud_sdk._service.files_service import DeepsetCloudFile, FilesService
 from deepset_cloud_sdk.models import UserInfo
 
@@ -29,192 +30,49 @@ def file_service(mocked_upload_sessions_api: Mock, mocked_files_api: Mock, mocke
 
 
 @pytest.mark.asyncio
-class TestUploadsFileService:
-    class TestFilePathsUpload:
-        async def test_upload_file_paths(
-            self,
-            file_service: FilesService,
-            mocked_upload_sessions_api: Mock,
-            upload_session_response: UploadSession,
-            mocked_s3: Mock,
-        ) -> None:
-            mocked_upload_sessions_api.create.return_value = upload_session_response
-            mocked_upload_sessions_api.status.return_value = UploadSessionStatus(
-                session_id=upload_session_response.session_id,
-                expires_at=upload_session_response.expires_at,
-                documentation_url=upload_session_response.documentation_url,
-                ingestion_status=UploadSessionIngestionStatus(
-                    failed_files=0,
-                    finished_files=1,
-                ),
-            )
-            await file_service.upload_file_paths(
-                workspace_name="test_workspace",
-                file_paths=[Path("./tmp/my-file")],
-                write_mode=WriteMode.OVERWRITE,
-                blocking=True,
-                timeout_s=300,
-            )
+class TestFilePathsUpload:
+    async def test_upload_file_paths(
+        self,
+        file_service: FilesService,
+        mocked_upload_sessions_api: Mock,
+        upload_session_response: UploadSession,
+        mocked_s3: Mock,
+    ) -> None:
+        upload_summary = S3UploadSummary(total_files=1, successful_upload_count=1, failed_upload_count=0, failed=[])
+        mocked_s3.upload_files_from_paths.return_value = upload_summary
+        mocked_upload_sessions_api.create.return_value = upload_session_response
+        mocked_upload_sessions_api.status.return_value = UploadSessionStatus(
+            session_id=upload_session_response.session_id,
+            expires_at=upload_session_response.expires_at,
+            documentation_url=upload_session_response.documentation_url,
+            ingestion_status=UploadSessionIngestionStatus(
+                failed_files=0,
+                finished_files=1,
+            ),
+        )
+        result = await file_service.upload_file_paths(
+            workspace_name="test_workspace",
+            file_paths=[Path("./tmp/my-file")],
+            write_mode=WriteMode.OVERWRITE,
+            blocking=True,
+            timeout_s=300,
+        )
+        assert result == upload_summary
 
-            mocked_upload_sessions_api.create.assert_called_once_with(
-                workspace_name="test_workspace", write_mode=WriteMode.OVERWRITE
-            )
+        mocked_upload_sessions_api.create.assert_called_once_with(
+            workspace_name="test_workspace", write_mode=WriteMode.OVERWRITE
+        )
 
-            mocked_s3.upload_files_from_paths.assert_called_once_with(
-                upload_session=upload_session_response, file_paths=[Path("./tmp/my-file")]
-            )
+        mocked_s3.upload_files_from_paths.assert_called_once_with(
+            upload_session=upload_session_response, file_paths=[Path("./tmp/my-file")]
+        )
 
-            mocked_upload_sessions_api.close.assert_called_once_with(
-                workspace_name="test_workspace", session_id=upload_session_response.session_id
-            )
-            mocked_upload_sessions_api.status.assert_called_once_with(
-                workspace_name="test_workspace", session_id=upload_session_response.session_id
-            )
-
-        async def test_upload_file_paths_with_timeout(
-            self,
-            file_service: FilesService,
-            mocked_upload_sessions_api: Mock,
-            upload_session_response: UploadSession,
-        ) -> None:
-            mocked_upload_sessions_api.create.return_value = upload_session_response
-            mocked_upload_sessions_api.status.return_value = UploadSessionStatus(
-                session_id=upload_session_response.session_id,
-                expires_at=upload_session_response.expires_at,
-                documentation_url=upload_session_response.documentation_url,
-                ingestion_status=UploadSessionIngestionStatus(
-                    failed_files=0,
-                    finished_files=0,
-                ),
-            )
-            with pytest.raises(TimeoutError):
-                await file_service.upload_file_paths(
-                    workspace_name="test_workspace", file_paths=[Path("./tmp/my-file")], blocking=True, timeout_s=0
-                )
-
-    class TestUpload:
-        async def test_upload_paths_to_folder(
-            self,
-            file_service: FilesService,
-            monkeypatch: MonkeyPatch,
-        ) -> None:
-            mocked_upload_file_paths = AsyncMock(return_value=None)
-            monkeypatch.setattr(FilesService, "upload_file_paths", mocked_upload_file_paths)
-            await file_service.upload(
-                workspace_name="test_workspace",
-                paths=[Path("./tests/data/upload_folder")],
-                blocking=True,
-                timeout_s=300,
-            )
-            assert mocked_upload_file_paths.called
-            assert "test_workspace" == mocked_upload_file_paths.call_args[1]["workspace_name"]
-            assert mocked_upload_file_paths.call_args[1]["blocking"] is True
-            assert 300 == mocked_upload_file_paths.call_args[1]["timeout_s"]
-
-            assert (
-                Path("tests/data/upload_folder/example.txt.meta.json")
-                in mocked_upload_file_paths.call_args[1]["file_paths"]
-            )
-            assert Path("tests/data/upload_folder/example.txt") in mocked_upload_file_paths.call_args[1]["file_paths"]
-            assert Path("tests/data/upload_folder/example.pdf") in mocked_upload_file_paths.call_args[1]["file_paths"]
-
-        async def test_upload_paths_nested(
-            self,
-            file_service: FilesService,
-            monkeypatch: MonkeyPatch,
-        ) -> None:
-            mocked_upload_file_paths = AsyncMock(return_value=None)
-            monkeypatch.setattr(FilesService, "upload_file_paths", mocked_upload_file_paths)
-            await file_service.upload(
-                workspace_name="test_workspace",
-                paths=[Path("./tests/data/upload_folder_nested")],
-                blocking=True,
-                timeout_s=300,
-                recursive=True,
-            )
-            assert mocked_upload_file_paths.called
-
-            assert (
-                Path("tests/data/upload_folder_nested/nested_folder/second.txt")
-                in mocked_upload_file_paths.call_args[1]["file_paths"]
-            )
-            assert (
-                Path("tests/data/upload_folder_nested/example.txt")
-                in mocked_upload_file_paths.call_args[1]["file_paths"]
-            )
-
-            assert (
-                Path("tests/data/upload_folder_nested/meta/example.txt.meta.json")
-                in mocked_upload_file_paths.call_args[1]["file_paths"]
-            )
-
-        async def test_upload_paths_to_file(
-            self,
-            file_service: FilesService,
-            monkeypatch: MonkeyPatch,
-        ) -> None:
-            mocked_upload_file_paths = AsyncMock(return_value=None)
-            monkeypatch.setattr(FilesService, "upload_file_paths", mocked_upload_file_paths)
-            await file_service.upload(
-                workspace_name="test_workspace",
-                paths=[Path("./tests/data/upload_folder/example.txt")],
-                blocking=True,
-                timeout_s=300,
-                recursive=True,
-            )
-            assert mocked_upload_file_paths.called
-            assert len(mocked_upload_file_paths.call_args[1]["file_paths"]) == 1
-
-            assert Path("tests/data/upload_folder/example.txt") in mocked_upload_file_paths.call_args[1]["file_paths"]
-
-    class TestUploadTexts:
-        async def test_upload_texts(
-            self,
-            file_service: FilesService,
-            mocked_upload_sessions_api: Mock,
-            upload_session_response: UploadSession,
-            mocked_s3: Mock,
-        ) -> None:
-            files = [
-                DeepsetCloudFile(
-                    name="test_file.txt",
-                    text="test content",
-                    meta={"test": "test"},
-                )
-            ]
-            mocked_upload_sessions_api.create.return_value = upload_session_response
-            mocked_upload_sessions_api.status.return_value = UploadSessionStatus(
-                session_id=upload_session_response.session_id,
-                expires_at=upload_session_response.expires_at,
-                documentation_url=upload_session_response.documentation_url,
-                ingestion_status=UploadSessionIngestionStatus(
-                    failed_files=0,
-                    finished_files=1,
-                ),
-            )
-            result = await file_service.upload_texts(
-                workspace_name="test_workspace",
-                files=files,
-                write_mode=WriteMode.OVERWRITE,
-                blocking=True,
-                timeout_s=300,
-                show_progress=False,
-            )
-
-            mocked_upload_sessions_api.create.assert_called_once_with(
-                workspace_name="test_workspace", write_mode=WriteMode.OVERWRITE
-            )
-
-            mocked_s3.upload_texts.assert_called_once_with(
-                upload_session=upload_session_response, files=files, show_progress=False
-            )
-
-            mocked_upload_sessions_api.close.assert_called_once_with(
-                workspace_name="test_workspace", session_id=upload_session_response.session_id
-            )
-            mocked_upload_sessions_api.status.assert_called_once_with(
-                workspace_name="test_workspace", session_id=upload_session_response.session_id
-            )
+        mocked_upload_sessions_api.close.assert_called_once_with(
+            workspace_name="test_workspace", session_id=upload_session_response.session_id
+        )
+        mocked_upload_sessions_api.status.assert_called_once_with(
+            workspace_name="test_workspace", session_id=upload_session_response.session_id
+        )
 
     async def test_upload_file_paths_with_timeout(
         self,
@@ -236,6 +94,158 @@ class TestUploadsFileService:
             await file_service.upload_file_paths(
                 workspace_name="test_workspace", file_paths=[Path("./tmp/my-file")], blocking=True, timeout_s=0
             )
+
+
+@pytest.mark.asyncio
+class TestUpload:
+    async def test_upload_paths_to_folder(
+        self,
+        file_service: FilesService,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        mocked_upload_file_paths = AsyncMock(return_value=None)
+        monkeypatch.setattr(FilesService, "upload_file_paths", mocked_upload_file_paths)
+        await file_service.upload(
+            workspace_name="test_workspace",
+            paths=[Path("./tests/data/upload_folder")],
+            blocking=True,
+            timeout_s=300,
+        )
+        assert mocked_upload_file_paths.called
+        assert "test_workspace" == mocked_upload_file_paths.call_args[1]["workspace_name"]
+        assert mocked_upload_file_paths.call_args[1]["blocking"] is True
+        assert 300 == mocked_upload_file_paths.call_args[1]["timeout_s"]
+
+        assert (
+            Path("tests/data/upload_folder/example.txt.meta.json")
+            in mocked_upload_file_paths.call_args[1]["file_paths"]
+        )
+        assert Path("tests/data/upload_folder/example.txt") in mocked_upload_file_paths.call_args[1]["file_paths"]
+        assert Path("tests/data/upload_folder/example.pdf") in mocked_upload_file_paths.call_args[1]["file_paths"]
+
+    async def test_upload_paths_nested(
+        self,
+        file_service: FilesService,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        mocked_upload_file_paths = AsyncMock(return_value=None)
+        monkeypatch.setattr(FilesService, "upload_file_paths", mocked_upload_file_paths)
+        await file_service.upload(
+            workspace_name="test_workspace",
+            paths=[Path("./tests/data/upload_folder_nested")],
+            blocking=True,
+            timeout_s=300,
+            recursive=True,
+        )
+        assert mocked_upload_file_paths.called
+
+        assert (
+            Path("tests/data/upload_folder_nested/nested_folder/second.txt")
+            in mocked_upload_file_paths.call_args[1]["file_paths"]
+        )
+        assert (
+            Path("tests/data/upload_folder_nested/example.txt") in mocked_upload_file_paths.call_args[1]["file_paths"]
+        )
+
+        assert (
+            Path("tests/data/upload_folder_nested/meta/example.txt.meta.json")
+            in mocked_upload_file_paths.call_args[1]["file_paths"]
+        )
+
+    async def test_upload_paths_to_file(
+        self,
+        file_service: FilesService,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        mocked_upload_file_paths = AsyncMock(return_value=None)
+        monkeypatch.setattr(FilesService, "upload_file_paths", mocked_upload_file_paths)
+        await file_service.upload(
+            workspace_name="test_workspace",
+            paths=[Path("./tests/data/upload_folder/example.txt")],
+            blocking=True,
+            timeout_s=300,
+            recursive=True,
+        )
+        assert mocked_upload_file_paths.called
+        assert len(mocked_upload_file_paths.call_args[1]["file_paths"]) == 1
+
+        assert Path("tests/data/upload_folder/example.txt") in mocked_upload_file_paths.call_args[1]["file_paths"]
+
+
+@pytest.mark.asyncio
+class TestUploadTexts:
+    async def test_upload_texts(
+        self,
+        file_service: FilesService,
+        mocked_upload_sessions_api: Mock,
+        upload_session_response: UploadSession,
+        mocked_s3: Mock,
+    ) -> None:
+        upload_summary = S3UploadSummary(total_files=1, successful_upload_count=1, failed_upload_count=0, failed=[])
+        mocked_s3.upload_texts.return_value = upload_summary
+        files = [
+            DeepsetCloudFile(
+                name="test_file.txt",
+                text="test content",
+                meta={"test": "test"},
+            )
+        ]
+        mocked_upload_sessions_api.create.return_value = upload_session_response
+        mocked_upload_sessions_api.status.return_value = UploadSessionStatus(
+            session_id=upload_session_response.session_id,
+            expires_at=upload_session_response.expires_at,
+            documentation_url=upload_session_response.documentation_url,
+            ingestion_status=UploadSessionIngestionStatus(
+                failed_files=0,
+                finished_files=1,
+            ),
+        )
+        result = await file_service.upload_texts(
+            workspace_name="test_workspace",
+            files=files,
+            write_mode=WriteMode.OVERWRITE,
+            blocking=True,
+            timeout_s=300,
+            show_progress=False,
+        )
+        assert result == upload_summary
+
+        mocked_upload_sessions_api.create.assert_called_once_with(
+            workspace_name="test_workspace", write_mode=WriteMode.OVERWRITE
+        )
+
+        mocked_s3.upload_texts.assert_called_once_with(
+            upload_session=upload_session_response, files=files, show_progress=False
+        )
+
+        mocked_upload_sessions_api.close.assert_called_once_with(
+            workspace_name="test_workspace", session_id=upload_session_response.session_id
+        )
+        mocked_upload_sessions_api.status.assert_called_once_with(
+            workspace_name="test_workspace", session_id=upload_session_response.session_id
+        )
+
+
+@pytest.mark.asyncio
+async def test_upload_file_paths_with_timeout(
+    file_service: FilesService,
+    mocked_upload_sessions_api: Mock,
+    upload_session_response: UploadSession,
+) -> None:
+    mocked_upload_sessions_api.create.return_value = upload_session_response
+    mocked_upload_sessions_api.status.return_value = UploadSessionStatus(
+        session_id=upload_session_response.session_id,
+        expires_at=upload_session_response.expires_at,
+        documentation_url=upload_session_response.documentation_url,
+        ingestion_status=UploadSessionIngestionStatus(
+            failed_files=0,
+            finished_files=0,
+        ),
+    )
+    with pytest.raises(TimeoutError):
+        await file_service.upload_file_paths(
+            workspace_name="test_workspace", file_paths=[Path("./tmp/my-file")], blocking=True, timeout_s=0
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/async_client/test_async_workflow_files.py
+++ b/tests/unit/workflows/async_client/test_async_workflow_files.py
@@ -25,30 +25,12 @@ from deepset_cloud_sdk.workflows.async_client.files import (
     list_files,
     list_upload_sessions,
     upload,
-    upload_file_paths,
     upload_texts,
 )
 
 
 @pytest.mark.asyncio
 class TestUploadFiles:
-    async def test_upload_file_paths(self, monkeypatch: MonkeyPatch) -> None:
-        mocked_upload_file_paths = AsyncMock(return_value=None)
-
-        monkeypatch.setattr(FilesService, "upload_file_paths", mocked_upload_file_paths)
-        await upload_file_paths(
-            file_paths=[Path("./tests/data/example.txt")], write_mode=WriteMode.OVERWRITE, show_progress=False
-        )
-
-        mocked_upload_file_paths.assert_called_once_with(
-            workspace_name=DEFAULT_WORKSPACE_NAME,
-            file_paths=[Path("./tests/data/example.txt")],
-            write_mode=WriteMode.OVERWRITE,
-            blocking=True,
-            timeout_s=300,
-            show_progress=False,
-        )
-
     async def test_upload_show_progress(self, monkeypatch: MonkeyPatch) -> None:
         paths = [Path("./tests/data/example.txt")]
         mocked_preprocess = AsyncMock(return_value=paths)

--- a/tests/unit/workflows/sync_client/test_sync_workflow_files.py
+++ b/tests/unit/workflows/sync_client/test_sync_workflow_files.py
@@ -21,27 +21,8 @@ from deepset_cloud_sdk.workflows.sync_client.files import (
     list_files,
     list_upload_sessions,
     upload,
-    upload_file_paths,
     upload_texts,
 )
-
-
-@patch("deepset_cloud_sdk.workflows.sync_client.files.async_upload_file_paths")
-def test_upload_file_paths(async_file_upload_mock: AsyncMock) -> None:
-    upload_file_paths(
-        file_paths=[Path("./tests/data/example.txt")],
-        write_mode=WriteMode.FAIL,
-    )
-    async_file_upload_mock.assert_called_once_with(
-        file_paths=[Path("./tests/data/example.txt")],
-        api_key=None,
-        api_url=None,
-        workspace_name=DEFAULT_WORKSPACE_NAME,
-        write_mode=WriteMode.FAIL,
-        blocking=True,
-        timeout_s=300,
-        show_progress=True,
-    )
 
 
 @patch("deepset_cloud_sdk.workflows.sync_client.files.async_upload")


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/deepset-cloud-sdk/issues/102

### Proposed Changes?

- return upload session summary
- delete legacy upload paths method. We should use `upload` instead 
- fix tests that are not run by accident

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
