### PR TITLE
fix: disable timeouts

### DIFF
--- a/deepset_cloud_sdk/_service/files_service.py
+++ b/deepset_cloud_sdk/_service/files_service.py
@@ -63,7 +63,12 @@ class FilesService:
             yield cls(upload_sessions_api, files_api, S3(concurrency=30))
 
     async def _wait_for_finished(
-        self, workspace_name: str, session_id: UUID, total_files: int, timeout_s: int, show_progress: bool = True
+        self,
+        workspace_name: str,
+        session_id: UUID,
+        total_files: int,
+        timeout_s: Optional[int] = None,
+        show_progress: bool = True,
     ) -> None:
         start = time.time()
         ingested_files = 0
@@ -72,7 +77,7 @@ class FilesService:
             pbar = tqdm(total=total_files, desc="Ingestion Progress")
 
         while ingested_files < total_files:
-            if time.time() - start > timeout_s:
+            if timeout_s is not None and time.time() - start > timeout_s:
                 raise TimeoutError("Ingestion timed out.")
 
             upload_session_status = await self._upload_sessions.status(
@@ -130,8 +135,8 @@ class FilesService:
         file_paths: List[Path],
         write_mode: WriteMode = WriteMode.KEEP,
         blocking: bool = True,
-        timeout_s: int = 300,
         show_progress: bool = True,
+        timeout_s: Optional[int] = None,
     ) -> S3UploadSummary:
         """Upload a list of files to a workspace.
 
@@ -265,7 +270,7 @@ class FilesService:
         paths: List[Path],
         write_mode: WriteMode = WriteMode.KEEP,
         blocking: bool = True,
-        timeout_s: int = 300,
+        timeout_s: Optional[int] = None,
         show_progress: bool = True,
         recursive: bool = False,
     ) -> S3UploadSummary:
@@ -404,7 +409,7 @@ class FilesService:
         files: List[DeepsetCloudFile],
         write_mode: WriteMode = WriteMode.KEEP,
         blocking: bool = True,
-        timeout_s: int = 300,
+        timeout_s: Optional[int] = None,
         show_progress: bool = True,
     ) -> S3UploadSummary:  # noqa
         """
@@ -453,7 +458,7 @@ class FilesService:
         content: Optional[str] = None,
         odata_filter: Optional[str] = None,
         batch_size: int = 100,
-        timeout_s: int = 20,
+        timeout_s: Optional[int] = None,
     ) -> AsyncGenerator[List[File], None]:
         """List all files in a workspace.
 
@@ -474,7 +479,7 @@ class FilesService:
         after_value = None
         after_file_id = None
         while has_more:
-            if time.time() - start > timeout_s:
+            if timeout_s is not None and time.time() - start > timeout_s:
                 raise TimeoutError(f"Listing all files in workspace {workspace_name} timed out.")
             response = await self._files.list_paginated(
                 workspace_name,
@@ -497,7 +502,7 @@ class FilesService:
         workspace_name: str,
         is_expired: Optional[bool] = False,
         batch_size: int = 100,
-        timeout_s: int = 20,
+        timeout_s: Optional[int] = None,
     ) -> AsyncGenerator[List[UploadSessionDetail], None]:  # noqa: F821
         """List all upload sessions files in a workspace.
 
@@ -515,7 +520,7 @@ class FilesService:
 
         page_number: int = 1
         while has_more:
-            if time.time() - start > timeout_s:
+            if timeout_s is not None and time.time() - start > timeout_s:
                 raise TimeoutError(f"Listing all upload sessions files in workspace {workspace_name} timed out.")
             response = await self._upload_sessions.list(
                 workspace_name,

--- a/deepset_cloud_sdk/cli.py
+++ b/deepset_cloud_sdk/cli.py
@@ -118,7 +118,7 @@ def list_files(
     odata_filter: Optional[str] = None,
     workspace_name: str = DEFAULT_WORKSPACE_NAME,
     batch_size: int = 10,
-    timeout_s: int = 300,
+    timeout_s: Optional[int] = None,
 ) -> None:
     """List files that exist in the specified deepset Cloud workspace.
 
@@ -166,7 +166,7 @@ def list_upload_sessions(
     is_expired: Optional[bool] = False,
     workspace_name: str = DEFAULT_WORKSPACE_NAME,
     batch_size: int = 10,
-    timeout_s: int = 300,
+    timeout_s: Optional[int] = None,
 ) -> None:
     """List the details of all upload sessions for the specified workspace, including closed sessions.
 

--- a/deepset_cloud_sdk/workflows/async_client/files.py
+++ b/deepset_cloud_sdk/workflows/async_client/files.py
@@ -34,7 +34,7 @@ async def list_files(
     content: Optional[str] = None,
     odata_filter: Optional[str] = None,
     batch_size: int = 100,
-    timeout_s: int = 300,
+    timeout_s: Optional[int] = None,
 ) -> AsyncGenerator[List[File], None]:
     """List all files in a workspace.
 
@@ -71,7 +71,7 @@ async def list_upload_sessions(
     workspace_name: str = DEFAULT_WORKSPACE_NAME,
     is_expired: Optional[bool] = None,
     batch_size: int = 100,
-    timeout_s: int = 300,
+    timeout_s: Optional[int] = None,
 ) -> AsyncGenerator[List[UploadSessionDetail], None]:
     """List the details of all upload sessions for a given workspace, including the closed sessions.
 
@@ -125,7 +125,7 @@ async def upload(
     workspace_name: str = DEFAULT_WORKSPACE_NAME,
     write_mode: WriteMode = WriteMode.KEEP,
     blocking: bool = True,
-    timeout_s: int = 300,
+    timeout_s: Optional[int] = None,
     show_progress: bool = True,
     recursive: bool = False,
 ) -> S3UploadSummary:
@@ -205,7 +205,7 @@ async def upload_texts(
     workspace_name: str = DEFAULT_WORKSPACE_NAME,
     write_mode: WriteMode = WriteMode.KEEP,
     blocking: bool = True,
-    timeout_s: int = 300,
+    timeout_s: Optional[int] = None,
     show_progress: bool = True,
 ) -> S3UploadSummary:
     """Upload raw texts to deepset Cloud.

--- a/deepset_cloud_sdk/workflows/sync_client/files.py
+++ b/deepset_cloud_sdk/workflows/sync_client/files.py
@@ -41,7 +41,7 @@ def upload(
     workspace_name: str = DEFAULT_WORKSPACE_NAME,
     write_mode: WriteMode = WriteMode.KEEP,
     blocking: bool = True,
-    timeout_s: int = 300,
+    timeout_s: Optional[int] = None,
     show_progress: bool = True,
     recursive: bool = False,
 ) -> S3UploadSummary:
@@ -126,7 +126,7 @@ def upload_texts(
     workspace_name: str = DEFAULT_WORKSPACE_NAME,
     write_mode: WriteMode = WriteMode.KEEP,
     blocking: bool = True,
-    timeout_s: int = 300,
+    timeout_s: Optional[int] = None,
     show_progress: bool = True,
 ) -> S3UploadSummary:
     """Upload texts to deepset Cloud.
@@ -184,7 +184,7 @@ def list_files(
     content: Optional[str] = None,
     odata_filter: Optional[str] = None,
     batch_size: int = 100,
-    timeout_s: int = 300,
+    timeout_s: Optional[int] = None,
 ) -> Generator[List[File], None, None]:
     """List files in a deepset Cloud workspace.
 
@@ -222,7 +222,7 @@ def list_upload_sessions(
     workspace_name: str = DEFAULT_WORKSPACE_NAME,
     is_expired: Optional[bool] = False,
     batch_size: int = 100,
-    timeout_s: int = 300,
+    timeout_s: Optional[int] = None,
 ) -> Generator[List[UploadSessionDetail], None, None]:
     """List the details of all upload sessions, including the closed ones.
 

--- a/tests/unit/workflows/async_client/test_async_workflow_files.py
+++ b/tests/unit/workflows/async_client/test_async_workflow_files.py
@@ -65,7 +65,23 @@ class TestUploadFiles:
             paths=[Path("./tests/data/upload_folder")],
             write_mode=WriteMode.KEEP,
             blocking=True,
-            timeout_s=300,
+            timeout_s=None,
+            show_progress=True,
+            recursive=False,
+        )
+
+    async def test_upload_with_timeout(self, monkeypatch: MonkeyPatch) -> None:
+        mocked_upload = AsyncMock(return_value=None)
+
+        monkeypatch.setattr(FilesService, "upload", mocked_upload)
+        await upload(paths=[Path("./tests/data/upload_folder")], timeout_s=123)
+
+        mocked_upload.assert_called_once_with(
+            workspace_name=DEFAULT_WORKSPACE_NAME,
+            paths=[Path("./tests/data/upload_folder")],
+            write_mode=WriteMode.KEEP,
+            blocking=True,
+            timeout_s=123,
             show_progress=True,
             recursive=False,
         )
@@ -87,7 +103,7 @@ class TestUploadFiles:
             files=files,
             write_mode=WriteMode.KEEP,
             blocking=True,
-            timeout_s=300,
+            timeout_s=None,
             show_progress=True,
         )
 

--- a/tests/unit/workflows/sync_client/test_sync_workflow_files.py
+++ b/tests/unit/workflows/sync_client/test_sync_workflow_files.py
@@ -38,7 +38,7 @@ def test_upload_folder(async_upload_mock: AsyncMock) -> None:
         workspace_name=DEFAULT_WORKSPACE_NAME,
         write_mode=WriteMode.KEEP,
         blocking=True,
-        timeout_s=300,
+        timeout_s=None,
         show_progress=True,
         recursive=False,
     )
@@ -61,7 +61,29 @@ def test_upload_texts(async_upload_texts_mock: AsyncMock) -> None:
         workspace_name=DEFAULT_WORKSPACE_NAME,
         write_mode=WriteMode.KEEP,
         blocking=True,
-        timeout_s=300,
+        timeout_s=None,
+        show_progress=True,
+    )
+
+
+@patch("deepset_cloud_sdk.workflows.sync_client.files.async_upload_texts")
+def test_upload_texts_with_timeout(async_upload_texts_mock: AsyncMock) -> None:
+    files = [
+        DeepsetCloudFile(
+            name="test_file.txt",
+            text="test content",
+            meta={"test": "test"},
+        )
+    ]
+    upload_texts(files=files, timeout_s=123)
+    async_upload_texts_mock.assert_called_once_with(
+        files=files,
+        api_key=None,
+        api_url=None,
+        workspace_name=DEFAULT_WORKSPACE_NAME,
+        write_mode=WriteMode.KEEP,
+        blocking=True,
+        timeout_s=123,
         show_progress=True,
     )
 


### PR DESCRIPTION
### Related Issues

- hotfix

### Proposed Changes?

- disable timeout. By default don't cancel running processes for uploads

### How did you test it?
Existing tests.


### Notes for the reviewer

Users are currently reporting many timeouts that are expected. Since this timeout seems like an issue to users we should keep it open. Large sessions are expected to take longer than the default timeout. 

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
