### PR TITLE
fix: drop double encoding

### DIFF
--- a/tests/unit/s3/test_upload.py
+++ b/tests/unit/s3/test_upload.py
@@ -23,7 +23,6 @@ class TestUploadsS3:
                 ),
                 # additional special characters
                 ("""#%"'|<>{}`^[]~\\""", "_" * 15),
-                ("$£%\x09宿 a.txt", "%24%C2%A3__%E5%AE%BF%20a.txt"),
             ],
         )
         def test_make_safe_file_name(self, input_file_name: str, expected_file_name: str) -> None:


### PR DESCRIPTION
### Related Issues

- part 2 of https://github.com/deepset-ai/deepset-cloud-sdk/issues/114

### Proposed Changes?

`FormData` is already encoding stuff. No need to do it twice.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
