### PR TITLE
fix: flaky upload session integration test

### DIFF
--- a/tests/integration/api/test_integration_upload_sessions.py
+++ b/tests/integration/api/test_integration_upload_sessions.py
@@ -46,6 +46,5 @@ class TestCreateUploadSessions:
             )
 
             assert result.total > 0
-            assert result.has_more is True
             assert result.data is not None
             assert len(result.data) == 1


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes?

remove the assert for has_more for upload sessions list. This is already tested at unit level, but causes flakiness when run in CI due to all the tests running in the same workspace. sometimes other tests run before this one, which create upload sessions, and sometimes they don't, which results in flakiness.

### How did you test it?

ran the suite locally 5 times with no flakiness

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
