### PR TITLE
fix: use a unique prefix for sdk test workspaces

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,7 @@ def _wait_for_file_to_be_available(
 def workspace_name(integration_config: CommonConfig) -> Generator[str, None, None]:
     """Create a workspace for the tests and delete it afterwards."""
     fake = Faker()
-    workspace_name = f"test_{'_'.join(fake.words(3))}"
+    workspace_name = f"sdktest_{'_'.join(fake.words(3))}"
 
     logger.info("Creating workspace", workspace_name=workspace_name)
 


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes?

 <!--- In case of a bug: Describe what caused the issue and how you solved it-->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
