### PR TITLE
fix: workspace not deleted after failed test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,26 +124,28 @@ def workspace_name(integration_config: CommonConfig) -> Generator[str, None, Non
     )
     assert response.status_code in (HTTPStatus.CREATED, HTTPStatus.CONFLICT)
 
-    if len(_get_file_names(integration_config=integration_config, workspace_name=workspace_name)) == 0:
-        for i in range(15):
-            response = httpx.post(
-                f"{integration_config.api_url}/workspaces/{workspace_name}/files",
-                data={"text": "This is text"},
-                files={
-                    "meta": (None, json.dumps({"find": "me"}).encode("utf-8")),
-                },
-                params={"file_name": f"example{i}.txt"},
-                headers={"Authorization": f"Bearer {integration_config.api_key}"},
-            )
-            assert response.status_code == HTTPStatus.CREATED
+    try:
+        if len(_get_file_names(integration_config=integration_config, workspace_name=workspace_name)) == 0:
+            for i in range(15):
+                response = httpx.post(
+                    f"{integration_config.api_url}/workspaces/{workspace_name}/files",
+                    data={"text": "This is text"},
+                    files={
+                        "meta": (None, json.dumps({"find": "me"}).encode("utf-8")),
+                    },
+                    params={"file_name": f"example{i}.txt"},
+                    headers={"Authorization": f"Bearer {integration_config.api_key}"},
+                )
+                assert response.status_code == HTTPStatus.CREATED
 
-        _wait_for_file_to_be_available(integration_config, workspace_name, expected_file_count=15)
+            _wait_for_file_to_be_available(integration_config, workspace_name, expected_file_count=15)
 
-    yield workspace_name
+        yield workspace_name
 
-    response = httpx.delete(
-        f"{integration_config.api_url}/workspaces/{workspace_name}",
-        headers={"Authorization": f"Bearer {integration_config.api_key}"},
-    )
+    finally:
+        response = httpx.delete(
+            f"{integration_config.api_url}/workspaces/{workspace_name}",
+            headers={"Authorization": f"Bearer {integration_config.api_key}"},
+        )
 
-    assert response.status_code in (HTTPStatus.OK, HTTPStatus.NO_CONTENT)
+        assert response.status_code in (HTTPStatus.OK, HTTPStatus.NO_CONTENT)


### PR DESCRIPTION
### Related Issues

- fixes workspace not being deleted after failed test which causes workspace congestion in our e2e org.
- See https://github.com/deepset-ai/deepset-cloud-sdk/actions/runs/7017651743/job/19091373476

### Proposed Changes?

 <!--- In case of a bug: Describe what caused the issue and how you solved it-->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
