### PR TITLE
fix: integration tests retry for content filter

### DIFF
--- a/tests/integration/api/test_integration_files.py
+++ b/tests/integration/api/test_integration_files.py
@@ -1,4 +1,7 @@
+from datetime import timedelta
+
 import pytest
+import tenacity
 
 from deepset_cloud_sdk._api.config import CommonConfig
 from deepset_cloud_sdk._api.deepset_cloud_api import DeepsetCloudAPI
@@ -7,21 +10,34 @@ from deepset_cloud_sdk._api.files import FilesAPI
 
 @pytest.mark.asyncio
 class TestListFiles:
-    async def test_list_paginated(self, integration_config: CommonConfig, workspace_name: str) -> None:
+    async def test_list_paginated(
+        self,
+        integration_config: CommonConfig,
+        workspace_name: str,
+    ) -> None:
         async with DeepsetCloudAPI.factory(integration_config) as deepset_cloud_api:
             files_api = FilesAPI(deepset_cloud_api)
-            result = await files_api.list_paginated(
-                workspace_name=workspace_name,
-                limit=10,
-                name="example0.txt",
-                content="text",
-                odata_filter="find eq 'me'",
-            )
 
-            assert result.total == 1
-            assert result.has_more is False
-            assert len(result.data) == 1
-            found_file = result.data[0]
-            assert found_file.name == "example0.txt"
-            assert found_file.size > 0
-            assert found_file.meta == {"find": "me"}
+            # We need to retry fetching this, because the file itself is available
+            # immediately, but the search index might not be updated yet.
+            # We are searching by context here which is otherwise not available.
+            for attempt in tenacity.Retrying(
+                stop=tenacity.stop_after_delay(600),
+                wait=tenacity.wait_fixed(wait=timedelta(seconds=0.5)),
+                reraise=True,
+            ):
+                with attempt:
+                    result = await files_api.list_paginated(
+                        workspace_name=workspace_name,
+                        limit=10,
+                        name="example0.txt",
+                        content="text",
+                        odata_filter="find eq 'me'",
+                    )
+                    assert result.total == 1
+                    assert result.has_more is False
+                    assert len(result.data) == 1
+                    found_file = result.data[0]
+                    assert found_file.name == "example0.txt"
+                    assert found_file.size > 0
+                    assert found_file.meta == {"find": "me"}

--- a/tests/integration/api/test_integration_files.py
+++ b/tests/integration/api/test_integration_files.py
@@ -22,7 +22,7 @@ class TestListFiles:
             # immediately, but the search index might not be updated yet.
             # We are searching by context here which is otherwise not available.
             for attempt in tenacity.Retrying(
-                stop=tenacity.stop_after_delay(600),
+                stop=tenacity.stop_after_delay(300),
                 wait=tenacity.wait_fixed(wait=timedelta(seconds=0.5)),
                 reraise=True,
             ):


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes?

 <!--- In case of a bug: Describe what caused the issue and how you solved it-->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
