### PR TITLE
 Fix: mock file age in remove_duplicates test [DC-1120]

### DIFF
--- a/tests/unit/service/test_files_service.py
+++ b/tests/unit/service/test_files_service.py
@@ -968,24 +968,7 @@ class TestRemoveDuplicates:
     def test_remove_duplicates_without_dups(self, file_paths: List[Path], expected: List[Path]) -> None:
         assert FilesService._remove_duplicates(file_paths) == expected
 
-    @pytest.mark.parametrize(
-        "file_paths, expected",
-        [
-            (
-                [
-                    Path("tests/data/upload_folder_with_duplicates/file1.txt"),
-                    Path("tests/data/upload_folder_with_duplicates/file2.txt"),
-                    Path("tests/data/upload_folder_with_duplicates/old_files/file1.txt"),
-                    Path("tests/data/upload_folder_with_duplicates/old_files/file2.txt"),
-                ],
-                [
-                    Path("tests/data/upload_folder_with_duplicates/file1.txt"),
-                    Path("tests/data/upload_folder_with_duplicates/file2.txt"),
-                ],
-            ),
-        ],
-    )
-    def test_remove_duplicates_with_dups(self, file_paths: List[Path], expected: List[Path]) -> None:
+    def test_remove_duplicates_with_dups(self) -> None:
         file_paths = [
             Path("tests/data/upload_folder_with_duplicates/file1.txt"),
             Path("tests/data/upload_folder_with_duplicates/file2.txt"),

--- a/tests/unit/service/test_files_service.py
+++ b/tests/unit/service/test_files_service.py
@@ -968,7 +968,7 @@ class TestRemoveDuplicates:
     def test_remove_duplicates_without_dups(self, file_paths: List[Path], expected: List[Path]) -> None:
         assert FilesService._remove_duplicates(file_paths) == expected
 
-    def test_remove_duplicates_with_dups(self) -> None:
+    def test_remove_duplicates_with_dups(self, monkeypatch: MonkeyPatch) -> None:
         file_paths = [
             Path("tests/data/upload_folder_with_duplicates/file1.txt"),
             Path("tests/data/upload_folder_with_duplicates/file2.txt"),
@@ -981,7 +981,7 @@ class TestRemoveDuplicates:
         ]
         # mock file age to avoid relying on files in file system
         timestamp = time.time()
-        MonkeyPatch().setattr(
+        monkeypatch.setattr(
             os.stat_result,
             "st_mtime",
             PropertyMock(side_effect=[timestamp, timestamp - 1, timestamp - 2, timestamp - 3]),


### PR DESCRIPTION
### Related Issues

- fixes #DC-1120

### Proposed Changes?

 <!--- In case of a bug: Describe what caused the issue and how you solved it-->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

After pulling the changes of https://github.com/deepset-ai/deepset-cloud-sdk/pull/173/files , the file age had changed locally on my machine and the tests failed. I made the test independent of the actual file age, so we don't rely on the actual files in the file system . 

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
