### PR TITLE
fix: lower file type comparison

### DIFF
--- a/tests/integration/service/test_integration_files_service.py
+++ b/tests/integration/service/test_integration_files_service.py
@@ -197,10 +197,10 @@ class TestUploadsFileService:
                 ), f"Metadata was not uploaded correctly for file '{file.name}': {file.meta}"
 
         # Make sure that the metadata for File00.txt and file00.txt are mapped correctly
-        File00_metadata = [file.meta for file in uploaded_files if file.name == "File00.txt"]
+        File00_metadata = next((file.meta for file in uploaded_files if file.name == "File00.txt"), None)
         assert File00_metadata == {"file_name_duplicate_check": "File00.txt", "source": "multiple file types"}
 
-        file00_metadata = [file.meta for file in uploaded_files if file.name == "file00.txt"]
+        file00_metadata = next((file.meta for file in uploaded_files if file.name == "file00.txt"), None)
         assert file00_metadata == {"file_name_duplicate_check": "file00.txt", "source": "multiple file types"}
 
     async def test_upload_texts(self, integration_config: CommonConfig, workspace_name: str) -> None:

--- a/tests/integration/service/test_integration_files_service.py
+++ b/tests/integration/service/test_integration_files_service.py
@@ -200,12 +200,8 @@ class TestUploadsFileService:
         File00_metadata = [file.meta for file in uploaded_files if file.name == "File00.txt"]
         assert File00_metadata == {"file_name_duplicate_check": "File00.txt", "source": "multiple file types"}
 
-        assert File00_metadata[0].get("file_name_duplicate_check") == "File00.txt"
-
         file00_metadata = [file.meta for file in uploaded_files if file.name == "file00.txt"]
         assert file00_metadata == {"file_name_duplicate_check": "file00.txt", "source": "multiple file types"}
-
-        assert file00_metadata[0].get("file_name_duplicate_check") == "file00.txt"
 
     async def test_upload_texts(self, integration_config: CommonConfig, workspace_name: str) -> None:
         async with FilesService.factory(integration_config) as file_service:

--- a/tests/integration/service/test_integration_files_service.py
+++ b/tests/integration/service/test_integration_files_service.py
@@ -69,8 +69,8 @@ class TestUploadsFileService:
                 timeout_s=timeout,
                 desired_file_types=SUPPORTED_TYPE_SUFFIXES,
             )
-            assert result.total_files == 9
-            assert result.successful_upload_count == 9
+            assert result.total_files == 10
+            assert result.successful_upload_count == 10
             assert result.failed_upload_count == 0
             assert len(result.failed) == 0
 
@@ -160,8 +160,8 @@ class TestUploadsFileService:
                 timeout_s=timeout,
                 desired_file_types=SUPPORTED_TYPE_SUFFIXES,
             )
-            assert result.total_files == 20
-            assert result.successful_upload_count == 20
+            assert result.total_files == 22
+            assert result.successful_upload_count == 22
             assert result.failed_upload_count == 0
             assert len(result.failed) == 0
 

--- a/tests/integration/service/test_integration_files_service.py
+++ b/tests/integration/service/test_integration_files_service.py
@@ -10,6 +10,7 @@ from deepset_cloud_sdk._api.config import CommonConfig
 from deepset_cloud_sdk._api.files import File
 from deepset_cloud_sdk._api.upload_sessions import WriteMode
 from deepset_cloud_sdk._service.files_service import (
+    META_SUFFIX,
     SUPPORTED_TYPE_SUFFIXES,
     DeepsetCloudFile,
     FilesService,
@@ -37,7 +38,7 @@ class TestUploadsFileService:
             names_of_uploaded_files = [
                 file.name
                 for file in Path("./tests/test_data/msmarco.10").glob("*.txt")
-                if not file.name.endswith(".meta.json")
+                if not file.name.endswith(META_SUFFIX)
             ]
             # Check the metadata was uploaded correctly
             files: List[File] = []
@@ -76,7 +77,7 @@ class TestUploadsFileService:
             local_file_names: List[str] = [
                 file.name
                 for file in Path("./tests/test_data/multiple_file_types").glob("*")
-                if not file.name.endswith(".meta.json")
+                if not file.name.endswith(META_SUFFIX)
             ]
 
             uploaded_files: List[File] = []
@@ -119,7 +120,7 @@ class TestUploadsFileService:
             local_file_names: List[str] = [
                 file.name
                 for file in Path("./tests/test_data/msmarco.10").glob("*.txt")
-                if not file.name.endswith(".meta.json")
+                if not file.name.endswith(META_SUFFIX)
             ]
             # Check the metadata was uploaded correctly
             uploaded_files: List[File] = []
@@ -164,7 +165,7 @@ class TestUploadsFileService:
             local_file_names: List[str] = [
                 file.name
                 for file in Path("./tests/test_data/multiple_file_types").glob("*")
-                if not file.name.endswith(".meta.json")
+                if not file.name.endswith(META_SUFFIX)
             ]
 
             uploaded_files: List[File] = []

--- a/tests/integration/service/test_integration_files_service.py
+++ b/tests/integration/service/test_integration_files_service.py
@@ -198,11 +198,13 @@ class TestUploadsFileService:
 
         # Make sure that the metadata for File00.txt and file00.txt are mapped correctly
         File00_metadata = [file.meta for file in uploaded_files if file.name == "File00.txt"]
-        assert len(File00_metadata) == 1
+        assert File00_metadata == {"file_name_duplicate_check": "File00.txt", "source": "multiple file types"}
+
         assert File00_metadata[0].get("file_name_duplicate_check") == "File00.txt"
 
         file00_metadata = [file.meta for file in uploaded_files if file.name == "file00.txt"]
-        assert len(file00_metadata) == 1
+        assert file00_metadata == {"file_name_duplicate_check": "file00.txt", "source": "multiple file types"}
+
         assert file00_metadata[0].get("file_name_duplicate_check") == "file00.txt"
 
     async def test_upload_texts(self, integration_config: CommonConfig, workspace_name: str) -> None:

--- a/tests/integration/service/test_integration_files_service.py
+++ b/tests/integration/service/test_integration_files_service.py
@@ -180,8 +180,13 @@ class TestUploadsFileService:
             ):
                 uploaded_files += file_batch
 
-        # We already uploaded the same set of files in a previous test, so we expect files to exist twice
-        for local_file_name in local_file_names:
+        # We already uploaded the same set of files in a previous test, so we expect files to exist twice except for the
+        # Therefore we just use the "multiple_file_types" folder to check for duplicates
+        for local_file_name in [
+            file.name
+            for file in list(Path("./tests/test_data/multiple_file_types").glob("*"))
+            if not file.name.endswith(META_SUFFIX)
+        ]:
             count = sum(1 for uploaded_file in uploaded_files if uploaded_file.name == local_file_name)
             assert count >= 2, f"File '{local_file_name}' does not exist twice in uploaded files"
 

--- a/tests/test_data/multiple_file_types/file00.txt
+++ b/tests/test_data/multiple_file_types/file00.txt
@@ -1,0 +1,1 @@
+Some text as a Textfile of file file00.txt

--- a/tests/test_data/multiple_file_types/file00.txt.meta.json
+++ b/tests/test_data/multiple_file_types/file00.txt.meta.json
@@ -1,0 +1,3 @@
+{
+    "file_name_duplicate_check": "file00.txt"
+}

--- a/tests/test_data/multiple_file_types/file00.txt.meta.json
+++ b/tests/test_data/multiple_file_types/file00.txt.meta.json
@@ -1,3 +1,4 @@
 {
-    "file_name_duplicate_check": "file00.txt"
+    "file_name_duplicate_check": "file00.txt",
+    "source": "multiple file types"
 }

--- a/tests/test_data/multiple_file_types_caps/File00.txt
+++ b/tests/test_data/multiple_file_types_caps/File00.txt
@@ -1,0 +1,1 @@
+Some text as a Textfile of file File00.txt with capital letters and some small letters.

--- a/tests/test_data/multiple_file_types_caps/File00.txt.meta.json
+++ b/tests/test_data/multiple_file_types_caps/File00.txt.meta.json
@@ -1,0 +1,3 @@
+{
+    "file_name_duplicate_check": "File00.txt"
+}

--- a/tests/test_data/multiple_file_types_caps/File00.txt.meta.json
+++ b/tests/test_data/multiple_file_types_caps/File00.txt.meta.json
@@ -1,3 +1,4 @@
 {
-    "file_name_duplicate_check": "File00.txt"
+    "file_name_duplicate_check": "File00.txt",
+    "source": "multiple file types"
 }

--- a/tests/unit/service/test_files_service.py
+++ b/tests/unit/service/test_files_service.py
@@ -1079,7 +1079,7 @@ class TestGetAllowedFileTypes:
         assert file_types == [".pdf"]
 
     def test_get_allowed_file_types_manages_formatting(self) -> None:
-        desired = [".pdf", "txt", "XML", "PDF"]
+        desired = [".pdf", "txt", "xml", "XML", "PDF"]
         file_types = sorted(FilesService._get_allowed_file_types(desired))
         assert file_types == [".pdf", ".txt", ".xml"]
 


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/deepset-cloud-sdk/issues/184

### Proposed Changes?
- dont run lowercase comparison for metadata matching 

### How did you test it?
- integration tests 

### Notes for the reviewer
- we will skip files with capital suffixes as file types from now on 

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
