### PR TITLE
Docs: Move tupload_texts() example from guides to reference

### DIFF
--- a/deepset_cloud_sdk/workflows/async_client/files.py
+++ b/deepset_cloud_sdk/workflows/async_client/files.py
@@ -236,7 +236,7 @@ async def upload_texts(
     ```python
     import asyncio
     from deepset_cloud_sdk.workflows.async_client.files import upload_texts, DeepsetCloudFile
-    
+
     async def my_async_context() -> None:
         await upload_texts(
             api_key="<deepsetCloud_API_key>",
@@ -246,11 +246,11 @@ async def upload_texts(
                     name="example.txt",
                     text="this is text",
                     meta={"key": "value"},  # optional
-          )
-        ],
+                )
+            ],
             blocking=True,  # optional, by default True
             timeout_s=300,  # optional, by default 300
-    )
+        )
 
     # Run the async function
     if __name__ == "__main__":

--- a/deepset_cloud_sdk/workflows/async_client/files.py
+++ b/deepset_cloud_sdk/workflows/async_client/files.py
@@ -231,6 +231,31 @@ async def upload_texts(
     This may take a couple of minutes.
     :param timeout_s: Timeout in seconds for the `blocking` parameter.
     :param show_progress: Shows the upload progress.
+
+    Example:
+    ```python
+    import asyncio
+    from deepset_cloud_sdk.workflows.async_client.files import upload_texts, DeepsetCloudFile
+    
+    async def my_async_context() -> None:
+        await upload_texts(
+            api_key="<deepsetCloud_API_key>",
+            workspace_name="<default_workspace>",  # optional, by default the environment variable "DEFAULT_WORKSPACE_NAME" is used
+            files=[
+                DeepsetCloudFile(
+                    name="example.txt",
+                    text="this is text",
+                    meta={"key": "value"},  # optional
+          )
+        ],
+            blocking=True,  # optional, by default True
+            timeout_s=300,  # optional, by default 300
+    )
+
+# Run the async function
+if __name__ == "__main__":
+    asyncio.run(my_async_context())
+    ```
     """
     async with FilesService.factory(_get_config(api_key=api_key, api_url=api_url)) as file_service:
         return await file_service.upload_in_memory(

--- a/deepset_cloud_sdk/workflows/async_client/files.py
+++ b/deepset_cloud_sdk/workflows/async_client/files.py
@@ -252,9 +252,9 @@ async def upload_texts(
             timeout_s=300,  # optional, by default 300
     )
 
-# Run the async function
-if __name__ == "__main__":
-    asyncio.run(my_async_context())
+    # Run the async function
+    if __name__ == "__main__":
+        asyncio.run(my_async_context())
     ```
     """
     async with FilesService.factory(_get_config(api_key=api_key, api_url=api_url)) as file_service:

--- a/deepset_cloud_sdk/workflows/sync_client/files.py
+++ b/deepset_cloud_sdk/workflows/sync_client/files.py
@@ -155,6 +155,25 @@ def upload_texts(
     :param blocking: Whether to wait for the files to be uploaded and listed in deepset Cloud.
     :param timeout_s: Timeout in seconds for the `blocking` parameter.
     :param show_progress: Shows the upload progress.
+
+    Example:
+    ```python
+    from deepset_cloud_sdk.workflows.sync_client.files import upload_texts, DeepsetCloudFile
+
+    upload_texts(
+        api_key="<deepsetCloud_API_key>",
+        workspace_name="<default_workspace>", # optional, by default the environment variable "DEFAULT_WORKSPACE_NAME" is used
+        files=[
+            DeepsetCloudFile(
+            name="example.txt",
+            text="this is text",
+            meta={"key": "value"},  # optional
+        )
+    ],
+        blocking=True,  # optional, by default True
+        timeout_s=300,  # optional, by default 300
+)
+    ```
     """
     return asyncio.run(
         async_upload_texts(

--- a/deepset_cloud_sdk/workflows/sync_client/files.py
+++ b/deepset_cloud_sdk/workflows/sync_client/files.py
@@ -172,7 +172,7 @@ def upload_texts(
     ],
         blocking=True,  # optional, by default True
         timeout_s=300,  # optional, by default 300
-)
+    )
     ```
     """
     return asyncio.run(

--- a/deepset_cloud_sdk/workflows/sync_client/files.py
+++ b/deepset_cloud_sdk/workflows/sync_client/files.py
@@ -165,11 +165,11 @@ def upload_texts(
         workspace_name="<default_workspace>", # optional, by default the environment variable "DEFAULT_WORKSPACE_NAME" is used
         files=[
             DeepsetCloudFile(
-            name="example.txt",
-            text="this is text",
-            meta={"key": "value"},  # optional
-        )
-    ],
+                name="example.txt",
+                text="this is text",
+                meta={"key": "value"},  # optional
+            )
+        ],
         blocking=True,  # optional, by default True
         timeout_s=300,  # optional, by default 300
     )


### PR DESCRIPTION

### Proposed Changes?

SOLs suggested upload_bytes() is the method we should promote in the guides, since they can use it for all file types, not just text. I'm deleting upload_texts() examples from https://docs.cloud.deepset.ai/docs/upload-files-with-python#upload-texts-or-bytes and moving them to reference. The how-tos will just have examples of upload_bytes.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

I'm not sure the formatting is OK. 

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
