### PR TITLE
fix: case sensitive file extension checks and force them to lower cas…

### DIFF
--- a/deepset_cloud_sdk/_s3/upload.py
+++ b/deepset_cloud_sdk/_s3/upload.py
@@ -148,6 +148,11 @@ class S3:
         file_data = aiohttp.FormData(quote_fields=True)
         for key in aws_config.fields:
             file_data.add_field(key, aws_config.fields[key])
+
+        # lower case the suffix on upload
+        suffix = aws_safe_name.split(".")[-1]
+        aws_safe_name.replace(f".{suffix}", f".{suffix.lower()}")
+
         file_data.add_field("file", content, filename=aws_safe_name, content_type="text/plain")
         return file_data
 

--- a/deepset_cloud_sdk/_s3/upload.py
+++ b/deepset_cloud_sdk/_s3/upload.py
@@ -149,10 +149,6 @@ class S3:
         for key in aws_config.fields:
             file_data.add_field(key, aws_config.fields[key])
 
-        # lower case the suffix on upload
-        suffix = aws_safe_name.split(".")[-1]
-        aws_safe_name.replace(f".{suffix}", f".{suffix.lower()}")
-
         file_data.add_field("file", content, filename=aws_safe_name, content_type="text/plain")
         return file_data
 

--- a/deepset_cloud_sdk/_service/files_service.py
+++ b/deepset_cloud_sdk/_service/files_service.py
@@ -299,7 +299,7 @@ class FilesService:
         """
         logger.info("Validating file paths and metadata.")
         for file_path in file_paths:
-            if file_path.suffix not in SUPPORTED_TYPE_SUFFIXES:
+            if file_path.suffix.lower() not in SUPPORTED_TYPE_SUFFIXES:
                 raise ValueError(
                     f"Invalid file extension: {file_path.suffix}. Refer to the list of supported file types in `SUPPORTED_TYPE_SUFFIXES`. "
                     "Metadata files should have the `.meta.json` extension."
@@ -383,7 +383,7 @@ class FilesService:
         file_paths = [
             path
             for path in all_files
-            if path.is_file() and (path.suffix in allowed_file_types and not str(path).endswith(META_SUFFIX))
+            if path.is_file() and (path.suffix.lower() in allowed_file_types and not str(path).endswith(META_SUFFIX))
         ]
         combined_paths = meta_file_path + file_paths
 

--- a/deepset_cloud_sdk/_service/files_service.py
+++ b/deepset_cloud_sdk/_service/files_service.py
@@ -379,7 +379,9 @@ class FilesService:
         allowed_file_types: List[str] = FilesService._get_allowed_file_types(desired_file_types)
         allowed_meta_types: Tuple = tuple(f"{file_type}.meta.json" for file_type in allowed_file_types)
 
-        meta_file_path = [path for path in all_files if path.is_file() and str(path).endswith(allowed_meta_types)]
+        meta_file_path = [
+            path for path in all_files if path.is_file() and str(path.name.lower()).endswith(allowed_meta_types)
+        ]
         file_paths = [
             path
             for path in all_files

--- a/tests/test_data/case_sensitive_file_extensions/case_test.TXT
+++ b/tests/test_data/case_sensitive_file_extensions/case_test.TXT
@@ -1,0 +1,1 @@
+Some text as a Textfile of file File00.txt with capital letters and some small letters.

--- a/tests/test_data/case_sensitive_file_extensions/case_test.TXT.meta.json
+++ b/tests/test_data/case_sensitive_file_extensions/case_test.TXT.meta.json
@@ -1,0 +1,4 @@
+{
+    "file_extension_test": "case_test.TXT",
+    "source": "case_sensitive_file_extensions"
+}

--- a/tests/test_data/case_sensitive_file_extensions/case_test.txt
+++ b/tests/test_data/case_sensitive_file_extensions/case_test.txt
@@ -1,0 +1,1 @@
+Some text as a Textfile of file File00.txt with capital letters and some small letters.

--- a/tests/unit/service/test_files_service.py
+++ b/tests/unit/service/test_files_service.py
@@ -1017,6 +1017,18 @@ class TestValidateFilePaths:
             [Path("/home/user/file1.pptx"), Path("/home/user/file1.pptx.meta.json")],
             [Path("/home/user/file1.xlsx"), Path("/home/user/file1.xlsx.meta.json")],
             [Path("/home/user/file1.xml"), Path("/home/user/file1.xml.meta.json")],
+            [Path("/home/user/file1.Txt"), Path("/home/user/file2.txt")],
+            [Path("/home/user/file1.tXt"), Path("/home/user/file1.json")],
+            [Path("/home/user/file1.txT"), Path("/home/user/file1.txT.meta.json")],
+            [Path("/home/user/file1.PDF"), Path("/home/user/file1.PDF.meta.json")],
+            [Path("/home/user/file1.cSv"), Path("/home/user/file1.cSv.meta.json")],
+            [Path("/home/user/file1.Docx"), Path("/home/user/file1.Docx.meta.json")],
+            [Path("/home/user/file1.htML"), Path("/home/user/file1.htML.meta.json")],
+            [Path("/home/user/file1.Json"), Path("/home/user/file1.Json.meta.json")],
+            [Path("/home/user/file1.mD"), Path("/home/user/file1.mD.meta.json")],
+            [Path("/home/user/file1.ppTx"), Path("/home/user/file1.ppTx.meta.json")],
+            [Path("/home/user/file1.xlSx"), Path("/home/user/file1.xlSx.meta.json")],
+            [Path("/home/user/file1.XMl"), Path("/home/user/file1.XMl.meta.json")],
         ],
     )
     async def test_validate_file_paths(self, file_paths: List[Path], monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
…e on upload

### Related Issues

- fixes https://deepset.atlassian.net/browse/DC-1523

### Proposed Changes?

Force the file extension to be lower case to check against allowed extensions and on upload. All other checks, like checking for metadata files are left untouched.


### How did you test it?

Adjusted unit tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
