### PR TITLE
fix: minor reliability improvements

### DIFF
--- a/deepset_cloud_sdk/_api/config.py
+++ b/deepset_cloud_sdk/_api/config.py
@@ -48,6 +48,8 @@ API_KEY: str = os.getenv("API_KEY", "")
 # configuration to use a selectd workspace
 DEFAULT_WORKSPACE_NAME: str = os.getenv("DEFAULT_WORKSPACE_NAME", "")
 
+ASYNC_CLIENT_TIMEOUT: int = int(os.getenv("ASYNC_CLIENT_TIMEOUT", "300"))
+
 
 @dataclass
 class CommonConfig:

--- a/deepset_cloud_sdk/_api/deepset_cloud_api.py
+++ b/deepset_cloud_sdk/_api/deepset_cloud_api.py
@@ -169,6 +169,12 @@ class DeepsetCloudAPI:
         )
         return response
 
+    @retry(
+        retry=retry_if_exception_type(httpx.ConnectError),
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(1),
+        reraise=True,
+    )
     async def put(
         self,
         workspace_name: str,

--- a/deepset_cloud_sdk/_s3/upload.py
+++ b/deepset_cloud_sdk/_s3/upload.py
@@ -27,7 +27,9 @@ logger = structlog.get_logger(__name__)
 class RetryableHttpError(Exception):
     """An error that indicates a function should be retried."""
 
-    def __init__(self, error: Union[aiohttp.ClientResponseError, aiohttp.ServerDisconnectedError]) -> None:
+    def __init__(
+        self, error: Union[aiohttp.ClientResponseError, aiohttp.ServerDisconnectedError, aiohttp.ClientConnectionError]
+    ) -> None:
         """Store the original exception."""
         self.error = error
 

--- a/tests/unit/s3/test_upload.py
+++ b/tests/unit/s3/test_upload.py
@@ -228,3 +228,16 @@ class TestUploadsS3:
 
                 with pytest.raises(aiohttp.ClientResponseError):
                     await s3._upload_file_with_retries("one.txt", upload_session_response, "123", mock_session)
+
+        @patch("aiohttp.ClientSession")
+        async def test_upload_file_retries_for_client_connection_exception(
+            self,
+            mock_session: Mock,
+            upload_session_response: UploadSession,
+        ) -> None:
+            exception = aiohttp.ClientConnectionError()
+            with patch.object(aiohttp.ClientSession, "post", side_effect=exception):
+                s3 = S3()
+
+                with pytest.raises(RetryableHttpError):
+                    await s3._upload_file_with_retries("one.txt", upload_session_response, "123", mock_session)


### PR DESCRIPTION
### Related Issues

- fixes minor reliability issues

### Proposed Changes?
- make async client timeout configurable via `ASYNC_CLIENT_TIMEOUT` env variable (default of 5 mins is quite small)
- retry session close requests in case of httpx.ConnectErrors
- increase retry attempts for file upload requests from 3 to 5
- retry file uploads on `aiohttp.ClientConnectionErrors`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
