### PR TITLE
fix: Fix file suffix checking

### DIFF
--- a/deepset_cloud_sdk/_api/files.py
+++ b/deepset_cloud_sdk/_api/files.py
@@ -177,6 +177,11 @@ class FilesAPI:
         :param file_path: Path to the file to upload.
         :param file_name: Name of the file to upload.
         :param meta: Meta information to attach to the file.
+        :param write_mode: Specifies what to do when a file with the same name already exists in the workspace.
+        Possible options are:
+        KEEP - uploads the file with the same name and keeps both files in the workspace.
+        OVERWRITE - overwrites the file that is in the workspace.
+        FAIL - fails to upload the file with the same name.
         :return: ID of the uploaded file.
         """
         if isinstance(file_path, str):
@@ -210,7 +215,7 @@ class FilesAPI:
         """Directly upload files to deepset Cloud.
 
         :param workspace_name: Name of the workspace to use.
-        :param text: File text to upload.
+        :param content: File text to upload.
         :param file_name: Name of the file to upload.
         :param meta: Meta information to attach to the file.
         :param write_mode: Specifies what to do when a file with the same name already exists in the workspace.
@@ -220,7 +225,7 @@ class FilesAPI:
         FAIL - fails to upload the file with the same name.
         :return: ID of the uploaded file.
         """
-        file_name_suffix = f".{file_name.split('.')[1]}"
+        file_name_suffix = Path(file_name).suffix
         if file_name_suffix not in SUPPORTED_TYPE_SUFFIXES:
             raise NotMatchingFileTypeException(
                 f"File name {file_name} is not a supported file type. Please use one of {'` '.join(SUPPORTED_TYPE_SUFFIXES)} for text uploads."


### PR DESCRIPTION
### Related Issues

- fixes https://deepset.atlassian.net/jira/polaris/projects/DCD/ideas/view/3949566?selectedIssue=DCD-496

### Proposed Changes?

Updates the file suffix checker in the direct upload to only check the file type suffix using `Path`. Otherwise the check fails for valid file names that contain dots elsewhere such as `my_file_10.09.2024.pdf` which are valid and are fine to upload to dC. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
