### PR TITLE
chore: Make all supported file types default everywhere

### DIFF
--- a/deepset_cloud_sdk/_api/deepset_cloud_api.py
+++ b/deepset_cloud_sdk/_api/deepset_cloud_api.py
@@ -116,6 +116,7 @@ class DeepsetCloudAPI:
         :param workspace_name: Name of the workspace to use.
         :param endpoint: Endpoint to call.
         :param params: Query parameters to pass.
+        :param json: JSON data to pass.
         :param data: Data to pass.
         :param files: Files to pass.
         :param timeout_s: Timeout in seconds.

--- a/deepset_cloud_sdk/_service/files_service.py
+++ b/deepset_cloud_sdk/_service/files_service.py
@@ -423,7 +423,7 @@ class FilesService:
         timeout_s: Optional[int] = None,
         show_progress: bool = True,
         recursive: bool = False,
-        desired_file_types: List[str] = [".txt", ".pdf"],
+        desired_file_types: Optional[List[str]] = None,
         enable_parallel_processing: bool = False,
     ) -> S3UploadSummary:
         """Upload a list of file or folder paths to a workspace.
@@ -444,11 +444,13 @@ class FilesService:
         :param timeout_s: Timeout in seconds for the `blocking` parameter.
         :param show_progress If True, shows a progress bar for S3 uploads.
         :param recursive: If True, recursively uploads all files in the folder.
-        :param desired_file_types: A list of allowed file types to upload, defaults to ['.txt', '.pdf']
+        :param desired_file_types: A list of allowed file types to upload, defaults to
+        `[".txt", ".pdf", ".docx", ".pptx", ".xlsx", ".xml", ".csv", ".html", ".md", ".json"]`
         :param enable_parallel_processing: If `True`, the deepset Cloud will ingest the files in parallel.
             Use this to speed up the upload process and if you are not running concurrent uploads for the same files.
         :raises TimeoutError: If blocking is True and the ingestion takes longer than timeout_s.
         """
+        desired_file_types = desired_file_types or SUPPORTED_TYPE_SUFFIXES
         logger.info("Getting valid files from file path. This may take a few minutes.", recursive=recursive)
 
         if show_progress:

--- a/deepset_cloud_sdk/workflows/async_client/files.py
+++ b/deepset_cloud_sdk/workflows/async_client/files.py
@@ -21,6 +21,7 @@ from deepset_cloud_sdk._api.upload_sessions import (
 from deepset_cloud_sdk._s3.upload import S3UploadSummary
 from deepset_cloud_sdk._service.files_service import FilesService
 from deepset_cloud_sdk.models import DeepsetCloudFile, DeepsetCloudFileBytes
+from deepset_cloud_sdk._utils.constants import SUPPORTED_TYPE_SUFFIXES
 
 
 def _get_config(api_key: Optional[str] = None, api_url: Optional[str] = None) -> CommonConfig:
@@ -145,11 +146,12 @@ async def upload(
     :param timeout_s: Timeout in seconds for the upload.
     :param show_progress: Shows the upload progress.
     :param recursive: Uploads files from subdirectories as well.
-    :param desired_file_types: A list of allowed file types to upload, defaults to ['.txt', '.pdf'].
+    :param desired_file_types: A list of allowed file types to upload, defaults to
+    `[".txt", ".pdf", ".docx", ".pptx", ".xlsx", ".xml", ".csv", ".html", ".md", ".json"]`
     :param enable_parallel_processing: If `True`, the deepset Cloud will ingest the files in parallel.
         Use this to speed up the upload process and if you are not running concurrent uploads for the same files.
     """
-    desired_file_types = desired_file_types or [".txt", ".pdf"]
+    desired_file_types = desired_file_types or SUPPORTED_TYPE_SUFFIXES
     async with FilesService.factory(_get_config(api_key=api_key, api_url=api_url)) as file_service:
         return await file_service.upload(
             workspace_name=workspace_name,

--- a/deepset_cloud_sdk/workflows/async_client/files.py
+++ b/deepset_cloud_sdk/workflows/async_client/files.py
@@ -20,8 +20,8 @@ from deepset_cloud_sdk._api.upload_sessions import (
 )
 from deepset_cloud_sdk._s3.upload import S3UploadSummary
 from deepset_cloud_sdk._service.files_service import FilesService
-from deepset_cloud_sdk.models import DeepsetCloudFile, DeepsetCloudFileBytes
 from deepset_cloud_sdk._utils.constants import SUPPORTED_TYPE_SUFFIXES
+from deepset_cloud_sdk.models import DeepsetCloudFile, DeepsetCloudFileBytes
 
 
 def _get_config(api_key: Optional[str] = None, api_url: Optional[str] = None) -> CommonConfig:

--- a/deepset_cloud_sdk/workflows/sync_client/files.py
+++ b/deepset_cloud_sdk/workflows/sync_client/files.py
@@ -15,6 +15,7 @@ from deepset_cloud_sdk._api.upload_sessions import (
     WriteMode,
 )
 from deepset_cloud_sdk._s3.upload import S3UploadSummary
+from deepset_cloud_sdk._utils.constants import SUPPORTED_TYPE_SUFFIXES
 from deepset_cloud_sdk.models import DeepsetCloudFile, DeepsetCloudFileBytes
 from deepset_cloud_sdk.workflows.async_client.files import download as async_download
 from deepset_cloud_sdk.workflows.async_client.files import (
@@ -34,7 +35,6 @@ from deepset_cloud_sdk.workflows.async_client.files import (
     upload_texts as async_upload_texts,
 )
 from deepset_cloud_sdk.workflows.sync_client.utils import iter_over_async
-from deepset_cloud_sdk._utils.constants import SUPPORTED_TYPE_SUFFIXES
 
 logger = structlog.get_logger(__name__)
 

--- a/deepset_cloud_sdk/workflows/sync_client/files.py
+++ b/deepset_cloud_sdk/workflows/sync_client/files.py
@@ -34,6 +34,7 @@ from deepset_cloud_sdk.workflows.async_client.files import (
     upload_texts as async_upload_texts,
 )
 from deepset_cloud_sdk.workflows.sync_client.utils import iter_over_async
+from deepset_cloud_sdk._utils.constants import SUPPORTED_TYPE_SUFFIXES
 
 logger = structlog.get_logger(__name__)
 
@@ -67,11 +68,12 @@ def upload(  # pylint: disable=too-many-arguments
     :param timeout_s: Timeout in seconds for the `blocking` parameter.
     :param show_progress: Shows the upload progress.
     :param recursive: Uploads files from subfolders as well.
-    :param desired_file_types: A list of allowed file types to upload, defaults to ".txt, .pdf".
+    :param desired_file_types: A list of allowed file types to upload, defaults to
+    `[".txt", ".pdf", ".docx", ".pptx", ".xlsx", ".xml", ".csv", ".html", ".md", ".json"]`
     :param enable_parallel_processing: If `True`, the deepset Cloud will ingest the files in parallel.
         Use this to speed up the upload process and if you are not running concurrent uploads for the same files.
     """
-    desired_file_types = desired_file_types or [".txt", ".pdf"]
+    desired_file_types = desired_file_types or SUPPORTED_TYPE_SUFFIXES
     return asyncio.run(
         async_upload(
             paths=paths,

--- a/tests/unit/workflows/async_client/test_async_workflow_files.py
+++ b/tests/unit/workflows/async_client/test_async_workflow_files.py
@@ -19,6 +19,7 @@ from deepset_cloud_sdk._api.upload_sessions import (
     WriteMode,
 )
 from deepset_cloud_sdk._service.files_service import FilesService
+from deepset_cloud_sdk._utils.constants import SUPPORTED_TYPE_SUFFIXES
 from deepset_cloud_sdk.models import DeepsetCloudFile, UserInfo
 from deepset_cloud_sdk.workflows.async_client.files import (
     download,
@@ -86,7 +87,7 @@ class TestUploadFiles:
             timeout_s=123,
             show_progress=True,
             recursive=False,
-            desired_file_types=[".txt", ".pdf"],
+            desired_file_types=SUPPORTED_TYPE_SUFFIXES,
             enable_parallel_processing=False,
         )
 

--- a/tests/unit/workflows/async_client/test_async_workflow_files.py
+++ b/tests/unit/workflows/async_client/test_async_workflow_files.py
@@ -69,7 +69,7 @@ class TestUploadFiles:
             timeout_s=None,
             show_progress=True,
             recursive=False,
-            desired_file_types=[".txt", ".pdf"],
+            desired_file_types=SUPPORTED_TYPE_SUFFIXES,
             enable_parallel_processing=False,
         )
 

--- a/tests/unit/workflows/sync_client/test_sync_workflow_files.py
+++ b/tests/unit/workflows/sync_client/test_sync_workflow_files.py
@@ -14,6 +14,7 @@ from deepset_cloud_sdk._api.upload_sessions import (
     UploadSessionWriteModeEnum,
     WriteMode,
 )
+from deepset_cloud_sdk._utils.constants import SUPPORTED_TYPE_SUFFIXES
 from deepset_cloud_sdk.models import DeepsetCloudFile, UserInfo
 from deepset_cloud_sdk.workflows.sync_client.files import (
     download,
@@ -38,7 +39,7 @@ def test_upload_folder(async_upload_mock: AsyncMock) -> None:
         timeout_s=None,
         show_progress=True,
         recursive=False,
-        desired_file_types=[".txt", ".pdf"],
+        desired_file_types=SUPPORTED_TYPE_SUFFIXES,
         enable_parallel_processing=True,
     )
 


### PR DESCRIPTION
### Related Issues

Uses the constant `SUPPORTED_TYPE_SUFFIXES` every where relevant. Originally missed in some places when adding new file type support to dC.

### Proposed Changes?

 <!--- In case of a bug: Describe what caused the issue and how you solved it-->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
