### PR TITLE
fix: support s3 xml error messages

### DIFF
--- a/deepset_cloud_sdk/_s3/upload.py
+++ b/deepset_cloud_sdk/_s3/upload.py
@@ -146,7 +146,7 @@ class S3:
                 raise RetryableHttpError(cre) from cre
 
             try:
-                error_message = await response.json()
+                error_message = await response.text()
                 cre.message = cre.message + f" - {error_message}"
             except Exception:  # pylint: disable=broad-except
                 pass

--- a/tests/unit/s3/test_upload.py
+++ b/tests/unit/s3/test_upload.py
@@ -227,10 +227,10 @@ class TestUploadsS3:
             )
             with patch.object(aiohttp.ClientSession, "post") as post_mock:
                 post_mock.return_value.__aenter__.return_value.raise_for_status = MagicMock(side_effect=exception)
-                post_mock.return_value.__aenter__.return_value.json.return_value = {"error": "error"}
+                post_mock.return_value.__aenter__.return_value.text.return_value = "<xml>error</xml>"
                 s3 = S3()
 
-                with pytest.raises(aiohttp.ClientResponseError, match="reason - {'error': 'error'}"):
+                with pytest.raises(aiohttp.ClientResponseError, match="reason - <xml>error</xml>"):
                     await s3._upload_file_with_retries("one.txt", upload_session_response, "123", mock_session)
 
         @pytest.mark.parametrize("status", [400, 422, 501])
@@ -243,7 +243,7 @@ class TestUploadsS3:
             )
             with patch.object(aiohttp.ClientSession, "post") as post_mock:
                 post_mock.return_value.__aenter__.return_value.raise_for_status = MagicMock(side_effect=exception)
-                post_mock.return_value.__aenter__.return_value.json.side_effect = Exception("error")
+                post_mock.return_value.__aenter__.return_value.text.side_effect = Exception("error")
                 s3 = S3()
 
                 with pytest.raises(aiohttp.ClientResponseError, match="reason"):


### PR DESCRIPTION
### Related Issues

- s3 error messages are xml

### Proposed Changes?

 <!--- In case of a bug: Describe what caused the issue and how you solved it-->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
