### PR TITLE
fix: markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 The deepset Cloud SDK is an open source software development kit that provides convenient access to and integration with deepset Cloud, a powerful cloud offering for various natural language processing (NLP) tasks.
 This README provides an overview of the SDK and its features, and information on contributing to the project and exploring related resources.
 
-- [Official SDK Docs](https://docs.cloud.deepset.ai/docs/working-with-the-sdk))
+- [Official SDK Docs](https://docs.cloud.deepset.ai/docs/working-with-the-sdk)
 - Tutorials: 
     - [Uploading with CLI](https://docs.cloud.deepset.ai/docs/tutorial-uploading-files-with-cli) 
     - [Uploading with Python Methods](https://docs.cloud.deepset.ai/docs/tutorial-uploading-files-with-python-methods)


### PR DESCRIPTION
remove extra `)`