### PR TITLE
feat: drop file type restriction for upload

### DIFF
--- a/deepset_cloud_sdk/_api/files.py
+++ b/deepset_cloud_sdk/_api/files.py
@@ -18,7 +18,6 @@ from httpx import codes
 
 from deepset_cloud_sdk._api.deepset_cloud_api import DeepsetCloudAPI
 from deepset_cloud_sdk._api.upload_sessions import WriteMode
-from deepset_cloud_sdk._utils.constants import SUPPORTED_TYPE_SUFFIXES
 from deepset_cloud_sdk._utils.datetime import from_isoformat
 
 logger = structlog.get_logger(__name__)
@@ -225,12 +224,6 @@ class FilesAPI:
         FAIL - fails to upload the file with the same name.
         :return: ID of the uploaded file.
         """
-        file_name_suffix = Path(file_name).suffix
-        if file_name_suffix not in SUPPORTED_TYPE_SUFFIXES:
-            raise NotMatchingFileTypeException(
-                f"File name {file_name} is not a supported file type. Please use one of {'` '.join(SUPPORTED_TYPE_SUFFIXES)} for text uploads."
-            )
-
         response = await self._deepset_cloud_api.post(
             workspace_name,
             "files",

--- a/deepset_cloud_sdk/_service/files_service.py
+++ b/deepset_cloud_sdk/_service/files_service.py
@@ -343,8 +343,9 @@ class FilesService:
         return most_recent_files
 
     @staticmethod
-    def _get_allowed_file_types(desired_file_types: List[Any]) -> List[str]:
+    def _get_allowed_file_types(desired_file_types: List[str]) -> List[str]:
         """Filter `SUPPORTED_TYPE_SUFFIXES` by `desired_file_types`.
+
         If desired_file_types is empty, all supported file types are returned.
 
         :param desired_file_types: A list of desired file types.

--- a/deepset_cloud_sdk/_service/files_service.py
+++ b/deepset_cloud_sdk/_service/files_service.py
@@ -9,7 +9,7 @@ import time
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, AsyncGenerator, Dict, List, Optional, Sequence, Set, Union
+from typing import Any, AsyncGenerator, Dict, List, Optional, Sequence, Union
 from uuid import UUID
 
 import structlog
@@ -341,22 +341,6 @@ class FilesService:
             most_recent_files.append(most_recent_file)
 
         return most_recent_files
-
-    @staticmethod
-    def _get_allowed_file_types(desired_file_types: List[str]) -> List[str]:
-        """Filter `SUPPORTED_TYPE_SUFFIXES` by `desired_file_types`.
-
-        If desired_file_types is empty, all supported file types are returned.
-
-        :param desired_file_types: A list of desired file types.
-        :return: A list of desired file types that can be processed by deepset Cloud.
-        """
-        desired_types_processed: Set[str] = {
-            str(file_type) if str(file_type).startswith(".") else f".{str(file_type)}"
-            for file_type in desired_file_types
-        }
-
-        return list(desired_types_processed)
 
     @staticmethod
     def _preprocess_paths(

--- a/deepset_cloud_sdk/_service/files_service.py
+++ b/deepset_cloud_sdk/_service/files_service.py
@@ -346,10 +346,10 @@ class FilesService:
     def _get_allowed_file_types(desired_file_types: List[Any]) -> List[str]:
         """Filter `SUPPORTED_TYPE_SUFFIXES` by `desired_file_types`.
         If desired_file_types is empty, all supported file types are returned.
+
         :param desired_file_types: A list of desired file types.
         :return: A list of desired file types that can be processed by deepset Cloud.
         """
-
         desired_types_processed: Set[str] = {
             str(file_type) if str(file_type).startswith(".") else f".{str(file_type)}"
             for file_type in desired_file_types

--- a/deepset_cloud_sdk/_utils/constants.py
+++ b/deepset_cloud_sdk/_utils/constants.py
@@ -1,1 +1,0 @@
-SUPPORTED_TYPE_SUFFIXES = [".csv", ".docx", ".html", ".json", ".md", ".txt", ".pdf", ".pptx", ".xlsx", ".xml"]

--- a/deepset_cloud_sdk/cli.py
+++ b/deepset_cloud_sdk/cli.py
@@ -63,7 +63,6 @@ def upload(  # pylint: disable=too-many-arguments
         Use this to speed up the upload process. Make sure you are not running concurrent uploads for the same files.
     :param safe_mode: If `True`, disables ingesting files in parallel.
     """
-    use_type = use_type or [".txt", ".pdf"]
     sync_upload(
         paths=paths,
         api_key=api_key,

--- a/deepset_cloud_sdk/workflows/async_client/files.py
+++ b/deepset_cloud_sdk/workflows/async_client/files.py
@@ -20,7 +20,6 @@ from deepset_cloud_sdk._api.upload_sessions import (
 )
 from deepset_cloud_sdk._s3.upload import S3UploadSummary
 from deepset_cloud_sdk._service.files_service import FilesService
-from deepset_cloud_sdk._utils.constants import SUPPORTED_TYPE_SUFFIXES
 from deepset_cloud_sdk.models import DeepsetCloudFile, DeepsetCloudFileBytes
 
 
@@ -147,13 +146,12 @@ async def upload(
     :param timeout_s: Timeout in seconds for the upload.
     :param show_progress: Shows the upload progress.
     :param recursive: Uploads files from subdirectories as well.
-    :param desired_file_types: A list of allowed file types to upload, defaults to
-    `[".txt", ".pdf", ".docx", ".pptx", ".xlsx", ".xml", ".csv", ".html", ".md", ".json"]`
+    :param desired_file_types: A list of allowed file types to upload. If not provided, all
+        files are uploaded.
     :param enable_parallel_processing: If `True`, the deepset Cloud will ingest the files in parallel.
         Use this to speed up the upload process and if you are not running concurrent uploads for the same files.
     :param safe_mode: If `True`, the deepset Cloud will not ingest the files in parallel.
     """
-    desired_file_types = desired_file_types or SUPPORTED_TYPE_SUFFIXES
     async with FilesService.factory(_get_config(api_key=api_key, api_url=api_url, safe_mode=safe_mode)) as file_service:
         return await file_service.upload(
             workspace_name=workspace_name,

--- a/deepset_cloud_sdk/workflows/sync_client/files.py
+++ b/deepset_cloud_sdk/workflows/sync_client/files.py
@@ -15,7 +15,6 @@ from deepset_cloud_sdk._api.upload_sessions import (
     WriteMode,
 )
 from deepset_cloud_sdk._s3.upload import S3UploadSummary
-from deepset_cloud_sdk._utils.constants import SUPPORTED_TYPE_SUFFIXES
 from deepset_cloud_sdk.models import DeepsetCloudFile, DeepsetCloudFileBytes
 from deepset_cloud_sdk.workflows.async_client.files import download as async_download
 from deepset_cloud_sdk.workflows.async_client.files import (
@@ -69,13 +68,12 @@ def upload(  # pylint: disable=too-many-arguments
     :param timeout_s: Timeout in seconds for the `blocking` parameter.
     :param show_progress: Shows the upload progress.
     :param recursive: Uploads files from subfolders as well.
-    :param desired_file_types: A list of allowed file types to upload, defaults to
-    `[".txt", ".pdf", ".docx", ".pptx", ".xlsx", ".xml", ".csv", ".html", ".md", ".json"]`
+    :param desired_file_types: A list of allowed file types to upload. If not provided, all
+        files are uploaded.
     :param enable_parallel_processing: If `True`, deepset Cloud ingests files in parallel.
         Use this to speed up the upload process. Make sure you are not running concurrent uploads for the same files.
     :param safe_mode: If `True`, disables ingesting files in parallel.
     """
-    desired_file_types = desired_file_types or SUPPORTED_TYPE_SUFFIXES
     return asyncio.run(
         async_upload(
             paths=paths,

--- a/tests/integration/service/test_integration_files_service.py
+++ b/tests/integration/service/test_integration_files_service.py
@@ -9,11 +9,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from deepset_cloud_sdk._api.config import CommonConfig
 from deepset_cloud_sdk._api.files import File
 from deepset_cloud_sdk._api.upload_sessions import WriteMode
-from deepset_cloud_sdk._service.files_service import (
-    META_SUFFIX,
-    SUPPORTED_TYPE_SUFFIXES,
-    FilesService,
-)
+from deepset_cloud_sdk._service.files_service import META_SUFFIX, FilesService
 from deepset_cloud_sdk.models import DeepsetCloudFile, DeepsetCloudFileBytes
 
 
@@ -68,7 +64,7 @@ class TestUploadsFileService:
                 blocking=True,
                 write_mode=WriteMode.KEEP,
                 timeout_s=timeout,
-                desired_file_types=SUPPORTED_TYPE_SUFFIXES,
+                desired_file_types=[".csv", ".docx", ".html", ".json", ".md", ".txt", ".pdf", ".pptx", ".xlsx", ".xml"],
             )
             assert result.total_files == 10
             assert result.successful_upload_count == 10
@@ -159,7 +155,7 @@ class TestUploadsFileService:
                 blocking=True,
                 write_mode=WriteMode.KEEP,
                 timeout_s=timeout,
-                desired_file_types=SUPPORTED_TYPE_SUFFIXES,
+                desired_file_types=[".csv", ".docx", ".html", ".json", ".md", ".txt", ".pdf", ".pptx", ".xlsx", ".xml"],
             )
             assert result.total_files == 22
             assert result.successful_upload_count == 22

--- a/tests/unit/api/test_files.py
+++ b/tests/unit/api/test_files.py
@@ -376,15 +376,6 @@ class TestDirectUploadFilePath:
 
 @pytest.mark.asyncio
 class TestDirectUploadText:
-    async def test_direct_upload_file_for_wrong_file_type_name(self, files_api: FilesAPI) -> None:
-        with pytest.raises(NotMatchingFileTypeException):
-            await files_api.direct_upload_in_memory(
-                workspace_name="test_workspace",
-                file_name="basic.xls",
-                content=b"some text",
-                meta={},
-            )
-
     @pytest.mark.parametrize("error_code", [httpx.codes.NOT_FOUND, httpx.codes.SERVICE_UNAVAILABLE])
     async def test_direct_upload_file_failed(
         self, files_api: FilesAPI, mocked_deepset_cloud_api: Mock, error_code: int

--- a/tests/unit/service/test_files_service.py
+++ b/tests/unit/service/test_files_service.py
@@ -28,10 +28,7 @@ from deepset_cloud_sdk._api.upload_sessions import (
     WriteMode,
 )
 from deepset_cloud_sdk._s3.upload import S3UploadResult, S3UploadSummary
-from deepset_cloud_sdk._service.files_service import (
-    SUPPORTED_TYPE_SUFFIXES,
-    FilesService,
-)
+from deepset_cloud_sdk._service.files_service import FilesService
 from deepset_cloud_sdk.models import DeepsetCloudFile, UserInfo
 
 
@@ -212,7 +209,7 @@ class TestUpload:
             paths=[Path("./tests/data/upload_folder")],
             blocking=True,
             timeout_s=300,
-            desired_file_types=SUPPORTED_TYPE_SUFFIXES,
+            desired_file_types=[".csv", ".docx", ".html", ".json", ".md", ".txt", ".pdf", ".pptx", ".xlsx", ".xml"],
         )
         assert mocked_upload_file_paths.called
         assert "test_workspace" == mocked_upload_file_paths.call_args[1]["workspace_name"]
@@ -251,7 +248,7 @@ class TestUpload:
                 paths=[Path("./tests/data/upload_folder")],
                 blocking=True,
                 timeout_s=300,
-                desired_file_types=SUPPORTED_TYPE_SUFFIXES,
+                desired_file_types=[".csv", ".docx", ".html", ".json", ".md", ".txt", ".pdf", ".pptx", ".xlsx", ".xml"],
             )
             skip_log_line = next((log for log in cap_logs if log.get("event", None) == "Skipping file"), None)
             assert skip_log_line is not None
@@ -1107,28 +1104,6 @@ class TestPreprocessFiles:
             FilesService._preprocess_paths([Path("tests/data/upload_folder/example.txt")], spinner=None)
         except Exception as e:
             assert False, f"No error should have been thrown but got error of type '{type(e).__name__}'"
-
-
-class TestGetAllowedFileTypes:
-    @pytest.mark.parametrize("input", [[], None])
-    def test_get_allowed_file_types_empty_values(self, input: List[object] | None) -> None:
-        file_types = FilesService._get_allowed_file_types(input)
-        assert file_types == SUPPORTED_TYPE_SUFFIXES
-
-    def test_get_allowed_file_types(self) -> None:
-        desired = [".pdf", ".txt", ".xml"]
-        file_types = sorted(FilesService._get_allowed_file_types(desired))
-        assert file_types == desired
-
-    def test_get_allowed_file_types_unsupported_types(self) -> None:
-        desired = [".pdf", ".foo", "jpg", 2]
-        file_types = sorted(FilesService._get_allowed_file_types(desired))
-        assert file_types == [".pdf"]
-
-    def test_get_allowed_file_types_manages_formatting(self) -> None:
-        desired = [".pdf", "txt", "xml", "XML", "PDF"]
-        file_types = sorted(FilesService._get_allowed_file_types(desired))
-        assert file_types == [".pdf", ".txt", ".xml"]
 
 
 class TestGetFilePaths:

--- a/tests/unit/service/test_files_service.py
+++ b/tests/unit/service/test_files_service.py
@@ -1019,9 +1019,6 @@ class TestValidateFilePaths:
     @pytest.mark.parametrize(
         "file_paths",
         [
-            [Path("/home/user/.DS_Store")],
-            [Path("/home/user/file2.jpg")],
-            [Path("/home/user/file1.exe")],
             [Path("/home/user/file1.pdf"), Path("/home/user/file2.pdf.meta.json")],
             [Path("/home/user/file1.pdf"), Path("/home/user/file1.txt.meta.json")],
             [Path("/home/user/file1.txt"), Path("/home/user/file1.pdf.meta.json")],

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -69,7 +69,7 @@ class TestCLIMethods:
             timeout_s=None,
             show_progress=True,
             recursive=False,
-            desired_file_types=[".txt", ".pdf"],
+            desired_file_types=None,
             enable_parallel_processing=True,
             safe_mode=False,
         )
@@ -132,7 +132,7 @@ class TestCLIMethods:
             timeout_s=None,
             show_progress=True,
             recursive=False,
-            desired_file_types=[".txt", ".pdf"],
+            desired_file_types=None,
             enable_parallel_processing=False,
             safe_mode=True,
         )

--- a/tests/unit/workflows/async_client/test_async_workflow_files.py
+++ b/tests/unit/workflows/async_client/test_async_workflow_files.py
@@ -19,7 +19,6 @@ from deepset_cloud_sdk._api.upload_sessions import (
     WriteMode,
 )
 from deepset_cloud_sdk._service.files_service import FilesService
-from deepset_cloud_sdk._utils.constants import SUPPORTED_TYPE_SUFFIXES
 from deepset_cloud_sdk.models import DeepsetCloudFile, UserInfo
 from deepset_cloud_sdk.workflows.async_client.files import (
     download,
@@ -69,7 +68,7 @@ class TestUploadFiles:
             timeout_s=None,
             show_progress=True,
             recursive=False,
-            desired_file_types=SUPPORTED_TYPE_SUFFIXES,
+            desired_file_types=None,
             enable_parallel_processing=False,
         )
 
@@ -87,7 +86,7 @@ class TestUploadFiles:
             timeout_s=123,
             show_progress=True,
             recursive=False,
-            desired_file_types=SUPPORTED_TYPE_SUFFIXES,
+            desired_file_types=None,
             enable_parallel_processing=False,
         )
 

--- a/tests/unit/workflows/sync_client/test_sync_workflow_files.py
+++ b/tests/unit/workflows/sync_client/test_sync_workflow_files.py
@@ -14,7 +14,6 @@ from deepset_cloud_sdk._api.upload_sessions import (
     UploadSessionWriteModeEnum,
     WriteMode,
 )
-from deepset_cloud_sdk._utils.constants import SUPPORTED_TYPE_SUFFIXES
 from deepset_cloud_sdk.models import DeepsetCloudFile, UserInfo
 from deepset_cloud_sdk.workflows.sync_client.files import (
     download,
@@ -39,7 +38,7 @@ def test_upload_folder(async_upload_mock: AsyncMock) -> None:
         timeout_s=None,
         show_progress=True,
         recursive=False,
-        desired_file_types=SUPPORTED_TYPE_SUFFIXES,
+        desired_file_types=None,
         enable_parallel_processing=True,
         safe_mode=False,
     )
@@ -58,7 +57,7 @@ def test_upload_folder_safe_mode(async_upload_mock: AsyncMock) -> None:
         timeout_s=None,
         show_progress=True,
         recursive=False,
-        desired_file_types=SUPPORTED_TYPE_SUFFIXES,
+        desired_file_types=None,
         enable_parallel_processing=True,
         safe_mode=True,
     )


### PR DESCRIPTION
- https://deepset.atlassian.net/browse/DC-3508

This pull request removes the `SUPPORTED_TYPE_SUFFIXES` constant and updates the codebase to handle file type validation differently. The changes focus on simplifying the file upload process and removing redundant checks.

### Removal of `SUPPORTED_TYPE_SUFFIXES`:

* [`deepset_cloud_sdk/_api/files.py`](diffhunk://#diff-2917862807c8abbfbb07f4df690dc9c01ac93236e9ce9ff73d3dc7b98133f3a7L21): Removed the `SUPPORTED_TYPE_SUFFIXES` import and the file type validation check in `direct_upload_in_memory`. [[1]](diffhunk://#diff-2917862807c8abbfbb07f4df690dc9c01ac93236e9ce9ff73d3dc7b98133f3a7L21) [[2]](diffhunk://#diff-2917862807c8abbfbb07f4df690dc9c01ac93236e9ce9ff73d3dc7b98133f3a7L228-L233)
* [`deepset_cloud_sdk/_service/files_service.py`](diffhunk://#diff-7b64b0883c287e8f6400a4c5d16368736cfb1f496b9b5198a2731bfde8f0800cL12-R12): Removed the `SUPPORTED_TYPE_SUFFIXES` import and associated validation checks in various methods such as `upload_file_paths`, `_validate_file_paths`, and `_preprocess_paths`. [[1]](diffhunk://#diff-7b64b0883c287e8f6400a4c5d16368736cfb1f496b9b5198a2731bfde8f0800cL12-R12) [[2]](diffhunk://#diff-7b64b0883c287e8f6400a4c5d16368736cfb1f496b9b5198a2731bfde8f0800cL44) [[3]](diffhunk://#diff-7b64b0883c287e8f6400a4c5d16368736cfb1f496b9b5198a2731bfde8f0800cL229-R218) [[4]](diffhunk://#diff-7b64b0883c287e8f6400a4c5d16368736cfb1f496b9b5198a2731bfde8f0800cL318-L323) [[5]](diffhunk://#diff-7b64b0883c287e8f6400a4c5d16368736cfb1f496b9b5198a2731bfde8f0800cL366-R363) [[6]](diffhunk://#diff-7b64b0883c287e8f6400a4c5d16368736cfb1f496b9b5198a2731bfde8f0800cL459)
* [`deepset_cloud_sdk/_utils/constants.py`](diffhunk://#diff-95c13050dfea2b0c2fa95e95d6db9d2ac1c8563dce20b644747da753afd16321L1): Completely removed the `SUPPORTED_TYPE_SUFFIXES` constant.

### Updates to file upload methods:

* [`deepset_cloud_sdk/cli.py`](diffhunk://#diff-d37ff2b557ac2955f6f5debc4f15b245e7704e556d03051ed43f795b1739e718L66): Removed the default `use_type` value in the `upload` function.
* [`deepset_cloud_sdk/workflows/async_client/files.py`](diffhunk://#diff-f4798ba335e0d38962f57792586f4cf0bf1dec117e502c38ca58221f0e8b63b8L23): Updated the `upload` function to remove default file types and handle all files if no specific types are provided. [[1]](diffhunk://#diff-f4798ba335e0d38962f57792586f4cf0bf1dec117e502c38ca58221f0e8b63b8L23) [[2]](diffhunk://#diff-f4798ba335e0d38962f57792586f4cf0bf1dec117e502c38ca58221f0e8b63b8L150-L156)
* [`deepset_cloud_sdk/workflows/sync_client/files.py`](diffhunk://#diff-14f799eba807d1f77664dcb2fd46076229a45fd36f130adc48b74b924aefd4a2L18): Similar updates to the synchronous `upload` function to handle all files if no specific types are provided. [[1]](diffhunk://#diff-14f799eba807d1f77664dcb2fd46076229a45fd36f130adc48b74b924aefd4a2L18) [[2]](diffhunk://#diff-14f799eba807d1f77664dcb2fd46076229a45fd36f130adc48b74b924aefd4a2L72-L78)

### Test updates:

* [`tests/integration/service/test_integration_files_service.py`](diffhunk://#diff-ae5b9fbe697072471affa477566bbef603c980a52f8d8eaac10c5924c4e3538dL12-R12): Updated tests to specify desired file types directly instead of using `SUPPORTED_TYPE_SUFFIXES`. [[1]](diffhunk://#diff-ae5b9fbe697072471affa477566bbef603c980a52f8d8eaac10c5924c4e3538dL12-R12) [[2]](diffhunk://#diff-ae5b9fbe697072471affa477566bbef603c980a52f8d8eaac10c5924c4e3538dL71-R67) [[3]](diffhunk://#diff-ae5b9fbe697072471affa477566bbef603c980a52f8d8eaac10c5924c4e3538dL162-R158)
* [`tests/unit/api/test_files.py`](diffhunk://#diff-2401588977a27c0a1d04f2912c56d22fd521ed77e8e1491069ba921667d68094L379-L387): Removed the test for invalid file type names.
* [`tests/unit/service/test_files_service.py`](diffhunk://#diff-cc857d744bee38fdbdddf85fd2e3e3bfec0e8fc489346643ad5f49c9f67873caL31-R31): Updated tests to specify desired file types directly and removed tests related to `SUPPORTED_TYPE_SUFFIXES`. [[1]](diffhunk://#diff-cc857d744bee38fdbdddf85fd2e3e3bfec0e8fc489346643ad5f49c9f67873caL31-R31) [[2]](diffhunk://#diff-cc857d744bee38fdbdddf85fd2e3e3bfec0e8fc489346643ad5f49c9f67873caL215-R212) [[3]](diffhunk://#diff-cc857d744bee38fdbdddf85fd2e3e3bfec0e8fc489346643ad5f49c9f67873caL254-R251) [[4]](diffhunk://#diff-cc857d744bee38fdbdddf85fd2e3e3bfec0e8fc489346643ad5f49c9f67873caL1025-L1027) [[5]](diffhunk://#diff-cc857d744bee38fdbdddf85fd2e3e3bfec0e8fc489346643ad5f49c9f67873caL1112-L1133)
* [`tests/unit/test_cli.py`](diffhunk://#diff-910473b6c2470739b209e36399cf9c87b9c7953c6813071ae3c3d2404b924553L72-R72): Updated tests to handle `desired_file_types` as `None` by default. [[1]](diffhunk://#diff-910473b6c2470739b209e36399cf9c87b9c7953c6813071ae3c3d2404b924553L72-R72) [[2]](diffhunk://#diff-910473b6c2470739b209e36399cf9c87b9c7953c6813071ae3c3d2404b924553L135-R135)
* [`tests/unit/workflows/async_client/test_async_workflow_files.py`](diffhunk://#diff-990814e8f3badda6f9117528525b4e09fe8bf6cc2a5d3aae2028678652a0c980L22): Updated the `upload` test to handle `desired_file_types` as `None` by default. [[1]](diffhunk://#diff-990814e8f3badda6f9117528525b4e09fe8bf6cc2a5d3aae2028678652a0c980L22) [[2]](diffhunk://#diff-990814e8f3badda6f9117528525b4e09fe8bf6cc2a5d3aae2028678652a0c980L72-R71)