### PR TITLE
fix: limiter leaking filedescriptors

### DIFF
--- a/deepset_cloud_sdk/_s3/upload.py
+++ b/deepset_cloud_sdk/_s3/upload.py
@@ -99,6 +99,8 @@ class S3:
     ) -> None:
         """Exit the context manager."""
         await self.connector.close()
+        for bucket in self.limiter.buckets():
+            self.limiter.dispose(bucket)
 
     async def _upload_file_with_retries(
         self,


### PR DESCRIPTION
### Related Issues

- fixes limiter leaking 3 file descriptors per `upload` call

### Proposed Changes?
- manually release resources of limiter

### How did you test it?
- ran test script simulating a real world upload usage having multiple `asyncio.run(upload)` invocations

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
