### PR TITLE
fix: pin click to 8.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "httpx>=0.27.2",
   "python-dotenv>=1.0.1",
   "typer>=0.16.0",
-  "click==8.2.0",  # fixed because of bug in 8.2.1, see https://github.com/deepset-ai/haystack-hub-api/pull/5127/files
+  "click==8.2.0",  # fixed because of bug in 8.2.1, see https://github.com/pallets/click/issues/2939
   "tenacity>=8.3.0",
   "aiohttp>=3.10.10",
   "aiofiles>=24.1.0",


### PR DESCRIPTION
### Related Issues

- Pin click to 8.2.0",  because of bug in 8.2.1, see https://github.com/pallets/click/issues/2939

### Proposed Changes?

 <!--- In case of a bug: Describe what caused the issue and how you solved it-->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
