### PR TITLE
fix: disable warnings about missing env variables if users passes them directly [DC-4217]

### DIFF
--- a/deepset_cloud_sdk/_api/config.py
+++ b/deepset_cloud_sdk/_api/config.py
@@ -12,13 +12,14 @@ logger = structlog.get_logger(__name__)
 ENV_FILE_PATH = Path.home() / ".deepset-cloud" / ".env"
 
 
-def load_environment() -> bool:
+def load_environment(show_warnings: bool = True) -> bool:
     """Load environment variables using a cascading fallback model.
 
     1. Load local .env file in current directory if it exists
     2. Load from global ~/.deepset-cloud/.env to supplement local .env file
     3. Environment variables can override both local and global .env files
 
+    :param show_warnings: Whether to show warnings about missing files/variables
     :return: True if required environment variables were loaded successfully, False otherwise.
     """
     current_path_env = Path.cwd() / ".env"
@@ -33,7 +34,7 @@ def load_environment() -> bool:
         else:
             logger.info(f"Environment variables successfully loaded from global .env file at {ENV_FILE_PATH}.")
 
-    if not (local_loaded or global_loaded):
+    if not (local_loaded or global_loaded) and show_warnings:
         logger.warning(
             "No .env files found. Run `deepset-cloud login` to create a global configuration file. "
             "You can also create a custom local .env file in your project directory."
@@ -44,7 +45,7 @@ def load_environment() -> bool:
     required_vars = ["API_KEY", "API_URL", "DEFAULT_WORKSPACE_NAME"]
     missing_vars = [var for var in required_vars if not os.getenv(var)]
 
-    if missing_vars:
+    if missing_vars and show_warnings:
         logger.warning(
             f"Missing required environment variables: {', '.join(missing_vars)}. "
             "Run `deepset-cloud login` to set up your configuration or set these variables "
@@ -55,7 +56,9 @@ def load_environment() -> bool:
     return True
 
 
-loaded_env_vars = load_environment()
+# Load environment variables silently at import time (no warnings)
+# This is needed for CLI commands to have access to DEFAULT_WORKSPACE_NAME
+load_environment(show_warnings=False)
 
 # connection to deepset AI Platform
 API_URL: str = os.getenv("API_URL", "https://api.cloud.deepset.ai/api/v1")
@@ -86,10 +89,21 @@ class CommonConfig:
 
     def __post_init__(self) -> None:
         """Validate config."""
+        # Only try loading from environment if we're using the global defaults
+        # (i.e., user didn't provide explicit parameters)
+        if self.api_key == API_KEY or self.api_url == API_URL:
+            load_environment(show_warnings=True)
+            if self.api_key == API_KEY:
+                self.api_key = os.getenv("API_KEY", "")
+            if self.api_url == API_URL:
+                self.api_url = os.getenv("API_URL", "https://api.cloud.deepset.ai/api/v1")
+
         assert (
             self.api_key != ""
-        ), "You must set the API_KEY environment variable. Go to [API Keys](https://cloud.deepset.ai/settings/api-keys) in deepset AI Platform to get an API key."
-        assert self.api_url != "", "API_URL environment variable must be set."
+        ), "API key is required. Either set the API_KEY environment variable or pass api_key parameter. Go to [API Keys](https://cloud.deepset.ai/settings/api-keys) in deepset AI Platform to get an API key."
+        assert (
+            self.api_url != ""
+        ), "API URL is required. Either set the API_URL environment variable or pass api_url parameter."
 
         if self.api_url.endswith("/"):
             self.api_url = self.api_url[:-1]

--- a/deepset_cloud_sdk/_api/config.py
+++ b/deepset_cloud_sdk/_api/config.py
@@ -56,8 +56,8 @@ def load_environment(show_warnings: bool = True) -> bool:
     return True
 
 
-# Load environment variables silently at import time (no warnings)
-# This is needed for CLI commands to have access to DEFAULT_WORKSPACE_NAME
+# Load environment variables silently at import time (no warnings) for cli commands.
+# Only raise warnings if variables are not explicitly provided in the code.
 load_environment(show_warnings=False)
 
 # connection to deepset AI Platform
@@ -83,19 +83,18 @@ class CommonConfig:
     5. Built-in defaults
     """
 
-    api_key: str = API_KEY
-    api_url: str = API_URL
+    api_key: str = ""
+    api_url: str = ""
     safe_mode: bool = False
 
     def __post_init__(self) -> None:
         """Validate config."""
-        # Only try loading from environment if we're using the global defaults
-        # (i.e., user didn't provide explicit parameters)
-        if self.api_key == API_KEY or self.api_url == API_URL:
+        # Only try loading from environment if user didn't provide explicit parameters)
+        if not self.api_key or not self.api_url:
             load_environment(show_warnings=True)
-            if self.api_key == API_KEY:
+            if not self.api_key:
                 self.api_key = os.getenv("API_KEY", "")
-            if self.api_url == API_URL:
+            if not self.api_url:
                 self.api_url = os.getenv("API_URL", "https://api.cloud.deepset.ai/api/v1")
 
         assert (

--- a/tests/unit/api/test_deepset_cloud_api.py
+++ b/tests/unit/api/test_deepset_cloud_api.py
@@ -31,17 +31,96 @@ class TestUtilitiesForDeepsetCloudAPI:
             await deepset_cloud_api.get("", "endpoint")
 
 
-@pytest.mark.asyncio
 class TestCommonConfig:
-    async def test_common_config_raises_exception_if_no_api_key_is_defined(self) -> None:
+    def test_common_config_raises_exception_if_no_api_key_is_defined(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Clear environment variables to ensure they don't interfere with the test
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.delenv("API_URL", raising=False)
+        monkeypatch.delenv("DEFAULT_WORKSPACE_NAME", raising=False)
+
+        # api key is not explicitly provided nor via env
         with pytest.raises(AssertionError):
             CommonConfig(api_key="", api_url="https://fake.dc.api")
 
-    async def test_common_config_raises_exception_if_no_api_url_is_defined(self) -> None:
+    def test_common_config_raises_exception_if_no_api_url_is_defined(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Clear environment variables to ensure they don't interfere with the test
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.delenv("API_URL", raising=False)
+        monkeypatch.delenv("DEFAULT_WORKSPACE_NAME", raising=False)
+
         with pytest.raises(AssertionError):
             CommonConfig(api_key="your-key", api_url="")
 
-    async def test_common_config_removes_last_backslash(self) -> None:
+    def test_common_config_works_with_explicit_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_load_env = Mock(return_value=True)
+        monkeypatch.setattr("deepset_cloud_sdk._api.config.load_environment", mock_load_env)
+
+        # When all parameters are provided explicitly, should not call load_environment
+        config = CommonConfig(api_key="explicit-key", api_url="https://explicit.api")
+
+        assert config.api_key == "explicit-key"
+        assert config.api_url == "https://explicit.api"
+
+        mock_load_env.assert_not_called()
+
+    def test_common_config_uses_env_vars_when_not_explicitly_provided(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Set environment variables
+        monkeypatch.setenv("API_KEY", "env-api-key")
+        monkeypatch.setenv("API_URL", "https://env.api.url")
+        monkeypatch.setenv("DEFAULT_WORKSPACE_NAME", "env-workspace")
+
+        mock_load_env = Mock(return_value=True)
+        monkeypatch.setattr("deepset_cloud_sdk._api.config.load_environment", mock_load_env)
+
+        # When no explicit parameters are provided, should use environment variables
+        config = CommonConfig()
+
+        assert config.api_key == "env-api-key"
+        assert config.api_url == "https://env.api.url"
+        # Should have called load_environment with warnings enabled
+        mock_load_env.assert_called_once_with(show_warnings=True)
+
+    def test_common_config_uses_env_vars_when_partially_provided_explicit_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("API_KEY", "env-api-key")
+        monkeypatch.setenv("API_URL", "https://env.api.url")
+        monkeypatch.setenv("DEFAULT_WORKSPACE_NAME", "env-workspace")
+
+        mock_load_env = Mock(return_value=True)
+        monkeypatch.setattr("deepset_cloud_sdk._api.config.load_environment", mock_load_env)
+
+        # When only api_key is provided explicitly, should use env var for api_url
+        config = CommonConfig(api_key="explicit-key")
+
+        assert config.api_key == "explicit-key"  # explicit value used
+        assert config.api_url == "https://env.api.url"  # env var used
+        # Should have called load_environment because api_url was not provided
+        mock_load_env.assert_called_once_with(show_warnings=True)
+
+    def test_common_config_uses_env_vars_when_partially_provided_explicit_api_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Set environment variables
+        monkeypatch.setenv("API_KEY", "env-api-key")
+        monkeypatch.setenv("API_URL", "https://env.api.url")
+        monkeypatch.setenv("DEFAULT_WORKSPACE_NAME", "env-workspace")
+
+        # Mock load_environment to avoid file system calls
+        from unittest.mock import Mock
+
+        mock_load_env = Mock(return_value=True)
+        monkeypatch.setattr("deepset_cloud_sdk._api.config.load_environment", mock_load_env)
+
+        # When only api_url is provided explicitly, should use env var for api_key
+        config = CommonConfig(api_url="https://explicit.api")
+
+        assert config.api_key == "env-api-key"  # env var used
+        assert config.api_url == "https://explicit.api"  # explicit value used
+        # Should have called load_environment because api_key was not provided
+        mock_load_env.assert_called_once_with(show_warnings=True)
+
+    def test_common_config_removes_last_backslash(self) -> None:
         assert CommonConfig(api_key="your-key", api_url="https://fake.dc.api/").api_url == "https://fake.dc.api"
 
 

--- a/tests/unit/api/test_deepset_cloud_api.py
+++ b/tests/unit/api/test_deepset_cloud_api.py
@@ -42,15 +42,6 @@ class TestCommonConfig:
         with pytest.raises(AssertionError):
             CommonConfig(api_key="", api_url="https://fake.dc.api")
 
-    def test_common_config_raises_exception_if_no_api_url_is_defined(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Clear environment variables to ensure they don't interfere with the test
-        monkeypatch.delenv("API_KEY", raising=False)
-        monkeypatch.delenv("API_URL", raising=False)
-        monkeypatch.delenv("DEFAULT_WORKSPACE_NAME", raising=False)
-
-        with pytest.raises(AssertionError):
-            CommonConfig(api_key="your-key", api_url="")
-
     def test_common_config_works_with_explicit_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_load_env = Mock(return_value=True)
         monkeypatch.setattr("deepset_cloud_sdk._api.config.load_environment", mock_load_env)
@@ -105,9 +96,6 @@ class TestCommonConfig:
         monkeypatch.setenv("API_KEY", "env-api-key")
         monkeypatch.setenv("API_URL", "https://env.api.url")
         monkeypatch.setenv("DEFAULT_WORKSPACE_NAME", "env-workspace")
-
-        # Mock load_environment to avoid file system calls
-        from unittest.mock import Mock
 
         mock_load_env = Mock(return_value=True)
         monkeypatch.setattr("deepset_cloud_sdk._api.config.load_environment", mock_load_env)


### PR DESCRIPTION
### Related Issues

- fixes https://deepset.atlassian.net/browse/DC-4217

### Proposed Changes?

 <!--- In case of a bug: Describe what caused the issue and how you solved it-->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
