### PR TITLE
fix: do not validate name if overwrite set to true

### DIFF
--- a/deepset_cloud_sdk/__init__.py
+++ b/deepset_cloud_sdk/__init__.py
@@ -14,6 +14,7 @@ from deepset_cloud_sdk.workflows.pipeline_client.models import (
     PipelineConfig,
     PipelineInputs,
     PipelineOutputs,
+    PipelineOutputType,
 )
 from deepset_cloud_sdk.workflows.pipeline_client.pipeline_service import (
     DeepsetValidationError,
@@ -37,4 +38,5 @@ __all__ = [
     "IndexInputs",
     "IndexOutputs",
     "DeepsetValidationError",
+    "PipelineOutputType",
 ]

--- a/deepset_cloud_sdk/workflows/__init__.py
+++ b/deepset_cloud_sdk/workflows/__init__.py
@@ -8,6 +8,7 @@ from deepset_cloud_sdk.workflows.pipeline_client.models import (
     PipelineConfig,
     PipelineInputs,
     PipelineOutputs,
+    PipelineOutputType,
 )
 from deepset_cloud_sdk.workflows.pipeline_client.pipeline_client import PipelineClient
 from deepset_cloud_sdk.workflows.pipeline_client.pipeline_service import (
@@ -26,4 +27,5 @@ __all__ = [
     "PipelineConfig",
     "PipelineClient",
     "DeepsetValidationError",
+    "PipelineOutputType",
 ]

--- a/deepset_cloud_sdk/workflows/pipeline_client/__init__.py
+++ b/deepset_cloud_sdk/workflows/pipeline_client/__init__.py
@@ -8,6 +8,7 @@ from deepset_cloud_sdk.workflows.pipeline_client.models import (
     PipelineConfig,
     PipelineInputs,
     PipelineOutputs,
+    PipelineOutputType,
 )
 from deepset_cloud_sdk.workflows.pipeline_client.pipeline_client import PipelineClient
 from deepset_cloud_sdk.workflows.pipeline_client.pipeline_service import (
@@ -26,4 +27,5 @@ __all__ = [
     "PipelineOutputs",
     "IndexConfig",
     "PipelineConfig",
+    "PipelineOutputType",
 ]

--- a/tests/integration/workflows/test_integration_pipeline_client.py
+++ b/tests/integration/workflows/test_integration_pipeline_client.py
@@ -312,7 +312,7 @@ class TestImportIndexIntoDeepset:
         validation_request = validation_route.calls[0].request
         assert validation_request.headers["Authorization"] == "Bearer test-api-key"
         validation_body = json.loads(validation_request.content)
-        assert validation_body["name"] == "test-index-fallback"
+        assert "indexing_yaml" in validation_body
 
         # Check PATCH attempt
         overwrite_request = overwrite_route.calls[0].request
@@ -505,7 +505,7 @@ class TestImportPipelineIntoDeepset:
         validation_request = validation_route.calls[0].request
         assert validation_request.headers["Authorization"] == "Bearer test-api-key"
         validation_body = json.loads(validation_request.content)
-        assert validation_body["name"] == "test-pipeline-fallback"
+        assert "query_yaml" in validation_body
 
         # Check PUT attempt
         overwrite_request = overwrite_route.calls[0].request


### PR DESCRIPTION
### Related Issues

- when overwriting existing pipelines, the validation would always warn about pipeline/index already existing
- Fixed by excluding the name from the validation call in case of overwrite
- Fixes import of PipelineOutputType

### Proposed Changes?

 <!--- In case of a bug: Describe what caused the issue and how you solved it-->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
