### PR TITLE
Fix: Remove example metadata filter

### DIFF
--- a/deepset_cloud_sdk/workflows/async_client/files.py
+++ b/deepset_cloud_sdk/workflows/async_client/files.py
@@ -43,10 +43,6 @@ async def list_files(
     :param workspace_name: Name of the workspace to list the files from. It uses the workspace from the .ENV file by default.
     :param name: Name of the file to odata_filter for.
     :param odata_filter: The odata_filter to apply to the file list.
-    For example, `odata_filter="category eq 'news'"` lists files with metadata:
-        ```json
-        {"meta": {"category": "news"}}
-        ```
     :param timeout_s: The timeout in seconds for this API call.
     :param batch_size: Batch size for the listing.
     :return: List of files.


### PR DESCRIPTION
### Related Issues



### Proposed Changes?

Need to remove this example as it breaks docs rendering and fails the docs build.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
