### PR TITLE
fix: make compatible with together

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
   "structlog>=24.0.0",
   "httpx>=0.27.2",
   "python-dotenv>=1.0.1",
-  "typer>=0.16.0",
-  "click==8.2.0",  # fixed because of bug in 8.2.1, see https://github.com/pallets/click/issues/2939
+  "typer>=0.15.0",
+  "click<=8.2.0",  # fixed because of bug in 8.2.1, see https://github.com/pallets/click/issues/2939
   "tenacity>=8.3.0",
   "aiohttp>=3.10.10",
   "aiofiles>=24.1.0",


### PR DESCRIPTION
### Related Issues

- fixes incompatibility to current [together](https://github.com/togethercomputer/together-python/blob/main/pyproject.toml) package
- fixes https://github.com/deepset-ai/haystack-schema-utils/actions/runs/16272746618/job/45944267651?pr=82

### Proposed Changes?
- tolerate older click and typer versions

### How did you test it?
- ran tests on click 8.1.8 and typer 0.15.4

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Screenshots (optional)

<!-- May be added to illustrate the changes -->

### Checklist

- [ ] I have updated the referenced issue with new insights and changes
- [ ] If this is a code change, I have added unit tests
- [ ] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I updated the docstrings
- [ ] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
