### PR TITLE
build: pin actions to long commit hashes and fix deploy-test for trusted publishing

### DIFF
--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.x
 
       - name: Setup cache
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ github.ref }}
           path: .cache
@@ -61,6 +61,6 @@ jobs:
           CATEGORY_ID: ${{env.CATEGORY_ID}}
 
       - name: Run `docs` command 🚀
-        uses: readmeio/rdme@v10
+        uses: readmeio/rdme@3c41af599df44e516c90ba4107a81c05d4945822 # v10.6.2
         with:
           rdme: docs docs/_pydoc/temp --key=${{ secrets.README_API_KEY }} --version=1.0

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -16,10 +16,10 @@ jobs:
     name: Check license compliance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           python-version: "3.10"

--- a/.github/workflows/continuous-deployment-dev.yml
+++ b/.github/workflows/continuous-deployment-dev.yml
@@ -14,7 +14,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run integration tests
         uses: ./.github/actions/integration_tests
         with:

--- a/.github/workflows/continuous-deployment-prod.yml
+++ b/.github/workflows/continuous-deployment-prod.yml
@@ -15,7 +15,7 @@ jobs:
     environment: PROD
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run integration tests
         uses: ./.github/actions/integration_tests
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,9 +12,9 @@ jobs:
     name: Format Code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           python-version: "3.10"
@@ -27,9 +27,9 @@ jobs:
     name: Lint Code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           python-version: "3.10"
@@ -42,9 +42,9 @@ jobs:
     name: Type checking with mypy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           python-version: "3.10"
@@ -57,7 +57,7 @@ jobs:
     name: Scan for secrets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Install gitleaks
@@ -73,12 +73,12 @@ jobs:
     env:
       API_KEY: "not-a-real-api-key"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # for coverage comment action
           fetch-depth: 1000
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           python-version: "3.10"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -28,6 +28,6 @@ jobs:
     - name: Build
       run: make build
     - name: publish
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         repository-url: ${{env.pypi}}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,9 +16,9 @@ jobs:
     env:
       pypi: ${{ vars.PYPI_URL }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         enable-cache: true
         python-version: "3.10"

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -18,9 +18,9 @@ jobs:
       pypi: ${{ vars.PYPI_URL }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           python-version: "3.10"

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -6,11 +6,27 @@ on:
       - labeled
   workflow_dispatch:
 
+permissions:
+  id-token: write
+
 jobs:
   deploy-test:
-    if: ${{ github.event.label.name == 'test-deploy' }} || github.event.label.name !='integration'`
-    uses: ./.github/workflows/deploy.yml
-    with:
-      deployment_env: test
-      api_url: "https://api.dev.cloud.dpst.dev/api/v1"
-    secrets: inherit
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'test-deploy') }}
+    runs-on: ubuntu-latest
+    environment: test
+    env:
+      pypi: ${{ vars.PYPI_URL }}
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: "3.10"
+      - name: Build
+        run: make build
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          repository-url: ${{ env.pypi }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,9 @@ jobs:
       pypi: ${{ vars.PYPI_URL }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           python-version: "3.10"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,6 @@ jobs:
       - name: Build
         run: make build
       - name: publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           repository-url: ${{env.pypi}}

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.event.action =='labeled' && github.event.label.name =='integration') || (github.event.action =='synchronize' && contains(github.event.pull_request.labels.*.name, 'integration')) || github.event.action =='workflow_call' || github.event_name == 'merge_group'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run integration tests
         uses: ./.github/actions/integration_tests
         with:
@@ -37,9 +37,9 @@ jobs:
     needs: [integration_tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           python-version: "3.10"


### PR DESCRIPTION
### Related Issues

We are already using trusted publishing for deploy.yml and deploy-prod.yml but I noticed deploy-test.yml is broken.

For context: I applied trusted publishing changes to haystack, haystack-experimental, haystack-core-integrations, hayhooks, and fastapi-openai-compat repos. Then came across deepset-cloud-sdk. The work started with related issues https://github.com/deepset-ai/haystack-private/issues/299 and https://github.com/deepset-ai/haystack-private/issues/137

### Proposed Changes?

- Used pinact to pin actions to long hashes
- Similar to https://github.com/deepset-ai/haystack/pull/10976, I aimed to stop the pypi release workflows from using a long-lived secret token and instead use trusted publishing. For that I transferred the workflow deploy-test.yml that reused the deploy workflow into a standalone workflow. The reason is that [this source](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing) states that:

> Trusted publishing cannot be used from within a reusable workflow at this time. It is recommended to instead create a non-reusable workflow that contains a job calling your reusable workflow, and then do the trusted publishing step from a separate job within that non-reusable workflow. Alternatively, you can still use a username/token inside the reusable workflow.

### How did you test it?

Tested similar changes with manually triggered pre-release in the haystack repository.

### Notes for the reviewer

The workflow deploy-test.yml probably wasn't working before? Had syntax errors: 
`if: ${{ github.event.label.name == 'test-deploy' }} || github.event.label.name !='integration'` and there was a trailing `. Further I believe there were some logic flaws.

After this PR get's merged, I will revoke the token on PyPI. I'd like to look into GitHub action secrets together with you. To me it looks like no changes are needed there.

### Checklist

- [x] I have updated the referenced issue with new insights and changes
- [x] If this is a code change, I have added unit tests
- [x] I've used the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I updated the docstrings
- [x] If this is a code change, I added meaningful logs and prepared Datadog visualizations and alerts
