### PR TITLE
fix(s3): replace fixed retry wait with exponential backoff (ECO-410)

### DIFF
--- a/deepset_cloud_sdk/_s3/upload.py
+++ b/deepset_cloud_sdk/_s3/upload.py
@@ -13,7 +13,7 @@ import aiofiles
 import aiohttp
 import structlog
 from pyrate_limiter import Duration, Limiter, Rate
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 from tqdm.asyncio import tqdm
 
 from deepset_cloud_sdk._api.config import ASYNC_CLIENT_TIMEOUT
@@ -147,7 +147,7 @@ class S3:
         @retry(
             retry=retry_if_exception_type(RetryableHttpError),
             stop=stop_after_attempt(self.max_attempts),
-            wait=wait_fixed(0.5),
+            wait=wait_exponential(multiplier=1, min=1, max=30),
             reraise=True,
         )
         async def retry_wrapper() -> aiohttp.ClientResponse:


### PR DESCRIPTION
## Summary

- Replaces `wait_fixed(0.5)` with `wait_exponential(multiplier=1, min=1, max=30)` in `S3._upload_file_with_retries`
- Retries now back off 1s → 2s → 4s → … → 30s instead of firing every 0.5s
- Prevents synchronized retry storms when many parallel uploads fail at once behind a corporate proxy — the root cause of continued connection exhaustion for ECO-410 after PR #308

## Test plan

- [ ] `uv run pytest tests/unit/s3/test_upload.py` — 23 passed

Closes ECO-410

🤖 Generated with [Claude Code](https://claude.com/claude-code)